### PR TITLE
Support accessing Netbox through a Layer 7 proxy

### DIFF
--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -70,7 +70,8 @@ class Api(object):
     """
 
     def __init__(
-        self, url, token=None, private_key=None, private_key_file=None, threading=False,
+        self, url, token=None, private_key=None, private_key_file=None,
+        threading=False, external_proxy=False,
     ):
         if private_key and private_key_file:
             raise ValueError(
@@ -93,6 +94,11 @@ class Api(object):
             with open(self.private_key_file, "r") as kf:
                 private_key = kf.read()
                 self.private_key = private_key
+
+        if isinstance(external_proxy, bool):
+            self.external_proxy = external_proxy
+        else:
+            raise ValueError('"external_proxy" must be True or False.')
 
         self.dcim = App(self, "dcim")
         self.ipam = App(self, "ipam")

--- a/pynetbox/core/app.py
+++ b/pynetbox/core/app.py
@@ -67,6 +67,7 @@ class App(object):
                 token=self.api.token,
                 private_key=self.api.private_key,
                 http_session=self.api.http_session,
+                external_proxy=self.api.external_proxy,
             ).get_session_key()
 
     def choices(self):
@@ -88,6 +89,7 @@ class App(object):
             token=self.api.token,
             private_key=self.api.private_key,
             http_session=self.api.http_session,
+            external_proxy=self.api.external_proxy,
         ).get()
 
         return self._choices
@@ -108,6 +110,7 @@ class App(object):
             token=self.api.token,
             private_key=self.api.private_key,
             http_session=self.api.http_session,
+            external_proxy=self.api.external_proxy,
         ).get()
         return custom_field_choices
 
@@ -132,6 +135,7 @@ class App(object):
             token=self.api.token,
             private_key=self.api.private_key,
             http_session=self.api.http_session,
+            external_proxy=self.api.external_proxy,
         ).get()
         return config
 
@@ -177,5 +181,6 @@ class PluginsApp(object):
             token=self.api.token,
             private_key=self.api.private_key,
             http_session=self.api.http_session,
+            external_proxy=self.api.external_proxy,
         ).get()
         return installed_plugins

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -99,6 +99,7 @@ class Endpoint(object):
             http_session=self.api.http_session,
             threading=self.api.threading,
             limit=limit,
+            external_proxy=self.api.external_proxy,
         )
 
         return RecordSet(self, req)
@@ -158,6 +159,7 @@ class Endpoint(object):
             token=self.token,
             session_key=self.session_key,
             http_session=self.api.http_session,
+            external_proxy=self.api.external_proxy,
         )
         try:
             return next(RecordSet(self, req), None)
@@ -247,6 +249,7 @@ class Endpoint(object):
             http_session=self.api.http_session,
             threading=self.api.threading,
             limit=kwargs.get("limit", 0),
+            external_proxy=self.api.external_proxy,
         )
 
         return RecordSet(self, req)
@@ -306,6 +309,7 @@ class Endpoint(object):
             token=self.token,
             session_key=self.session_key,
             http_session=self.api.http_session,
+            external_proxy=self.api.external_proxy,
         ).post(args[0] if args else kwargs)
 
         if isinstance(req, list):
@@ -349,6 +353,7 @@ class Endpoint(object):
             token=self.api.token,
             private_key=self.api.private_key,
             http_session=self.api.http_session,
+            external_proxy=self.api.external_proxy,
         ).options()
         try:
             post_data = req["actions"]["POST"]
@@ -409,6 +414,7 @@ class Endpoint(object):
             token=self.token,
             session_key=self.session_key,
             http_session=self.api.http_session,
+            external_proxy=self.api.external_proxy,
         )
 
         return ret.get_count()

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -244,6 +244,13 @@ class Request(object):
 
         return url
 
+    def _set_base_url(self, url):
+        """ 
+        Replace base url (before '/api/') with base_url from 
+        pynetbox.api() instantiation.
+        """
+        return self.base.split("/api/")[0] + "/api/" + url.split("/api/")[1]
+
     def _make_call(self, verb="get", url_override=None, add_params=None, data=None):
         if verb in ("post", "put"):
             headers = {"Content-Type": "application/json;"}
@@ -321,7 +328,11 @@ class Request(object):
                         increment * page_size for increment in range(1, pages)
                     ]
                     if pages == 1:
-                        req = self._make_call(url_override=req.get("next"))
+                        req = self._make_call(
+                                url_override=self._set_base_url(
+                                    req.get("next")
+                                    )
+                                )
                         ret.extend(req["results"])
                     else:
                         self.concurrent_get(ret, page_size, page_offsets)
@@ -343,7 +354,9 @@ class Request(object):
                             }
                         )
                     else:
-                        req = self._make_call(url_override=req["next"])
+                        req = self._make_call(
+                                url_override=self._set_base_url(req["next"])
+                                )
                     first_run = False
                     for i in req["results"]:
                         yield i

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -19,6 +19,7 @@ except ImportError:
     pass
 import json
 from six.moves.urllib.parse import urlencode
+from pynetbox.core.util import set_base_url
 
 
 def calc_pages(limit, count):
@@ -245,11 +246,9 @@ class Request(object):
         return url
 
     def _set_base_url(self, url):
-        """ 
-        Replace base url (before '/api/') with base_url from 
-        pynetbox.api() instantiation.
+        """ calls set_base_url with self.base_url as base
         """
-        return self.base.split("/api/")[0] + "/api/" + url.split("/api/")[1]
+        return set_base_url(self.base_url, url)
 
     def _make_call(self, verb="get", url_override=None, add_params=None, data=None):
         if verb in ("post", "put"):

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -228,7 +228,11 @@ class Record(object):
         self.api = api
         self.default_ret = Record
         self.endpoint = (
-            self._endpoint_from_url(values["url"])
+            # Replace base of values["url"] with api.base_url
+            # if netbox is behind an external proxy
+            self._endpoint_from_url(
+                api.base_url + values["url"].split("/api")[1]
+                )
             if values and "url" in values
             else endpoint
         )
@@ -319,6 +323,8 @@ class Record(object):
                     self._add_cache((k, copy.deepcopy(v)))
                     setattr(self, k, v)
                     continue
+                elif k == "url":
+                    v = self.api.base_url + v.split("/api")[1]
                 if lookup:
                     v = lookup(v, self.api, self.endpoint)
                 else:
@@ -331,6 +337,8 @@ class Record(object):
                 self._add_cache((k, to_cache))
 
             else:
+                if k == "url":
+                    v = self.api.base_url + v.split("/api")[1]
                 self._add_cache((k, v))
             setattr(self, k, v)
 

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -19,6 +19,7 @@ from collections import OrderedDict
 import pynetbox.core.app
 from six.moves.urllib.parse import urlsplit
 from pynetbox.core.query import Request, RequestError
+from pynetbox.core.util import set_base_url
 from pynetbox.core.util import Hashabledict
 
 
@@ -231,7 +232,7 @@ class Record(object):
             # Replace base of values["url"] with api.base_url
             # if netbox is behind an external proxy
             self._endpoint_from_url(
-                api.base_url + values["url"].split("/api")[1]
+                set_base_url(api.base_url, values["url"])
                 )
             if values and "url" in values
             else endpoint
@@ -324,7 +325,7 @@ class Record(object):
                     setattr(self, k, v)
                     continue
                 elif k == "url":
-                    v = self.api.base_url + v.split("/api")[1]
+                    v = set_base_url(self.api.base_url, values["url"])
                 if lookup:
                     v = lookup(v, self.api, self.endpoint)
                 else:
@@ -338,7 +339,7 @@ class Record(object):
 
             else:
                 if k == "url":
-                    v = self.api.base_url + v.split("/api")[1]
+                    v = set_base_url(self.api.base_url, values["url"])
                 self._add_cache((k, v))
             setattr(self, k, v)
 

--- a/pynetbox/core/util.py
+++ b/pynetbox/core/util.py
@@ -6,11 +6,15 @@ def set_base_url(base, url):
     pynetbox.api() instantiation.
     """
     b = urlsplit(base)
-    base_url = f'{b.scheme}://{b.netloc}{b.path.split("/api/")[0]}'
+    base_path = b.path if b.path.endswith('/') else f'{b.path}/'
+    split_base_path = base_path.split("/api/")[0]
+    base_url = f'{b.scheme}://{b.netloc}{split_base_path}'
 
     u = urlsplit(url)
-    path = u.path.split("/api/")[1]
-    return f'{base_url}/{path}'
+    url_path = u.path.split("/api/")[1]
+
+    return f'{base_url}/api/{url_path}?{u.query}'
+
 
 
 class Hashabledict(dict):

--- a/pynetbox/core/util.py
+++ b/pynetbox/core/util.py
@@ -1,3 +1,18 @@
+from six.moves.urllib.parse import urlsplit
+
+def set_base_url(base, url):
+    """ 
+    Replace base url (before '/api/') with base_url from 
+    pynetbox.api() instantiation.
+    """
+    b = urlsplit(base)
+    base_url = f'{b.scheme}://{b.netloc}{b.path.split("/api/")[0]}'
+
+    u = urlsplit(url)
+    path = u.path.split("/api/")[1]
+    return f'{base_url}/{path}'
+
+
 class Hashabledict(dict):
     def __hash__(self):
         return hash(frozenset(self))

--- a/pynetbox/models/dcim.py
+++ b/pynetbox/models/dcim.py
@@ -30,6 +30,7 @@ class TraceableRecord(Record):
             token=self.api.token,
             session_key=self.api.session_key,
             http_session=self.api.http_session,
+            external_proxy=self.api.external_proxy,
         ).get()
         uri_to_obj_class_map = {
             "dcim/cables": Cables,

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -38,6 +38,33 @@ class RequestTestCase(unittest.TestCase):
             json=None,
         )
 
+    def test_get_count_behind_external_proxy(self):
+        test_obj = Request(
+            http_session=Mock(),
+            base="http://example.com/netbox/api/dcim/devices",
+            filters={"q": "abcd"},
+        )
+        test_obj.http_session.get.return_value.json.return_value = {
+            "count": 42,
+            "next": "http://localhost:8001/api/dcim/devices?limit=1&offset=1&q=abcd",
+            "previous": False,
+            "results": [],
+        }
+        expected = call(
+            "http://localhost:8001/api/dcim/devices/",
+            params={"q": "abcd", "limit": 1},
+            headers={"accept": "application/json;"},
+        )
+        test_obj.http_session.get.ok = True
+        test = test_obj.get_count()
+        self.assertEqual(test, 42)
+        test_obj.http_session.get.assert_called_with(
+            "http://example.com/netbox/api/dcim/devices/",
+            params={"q": "abcd", "limit": 1},
+            headers={"accept": "application/json;"},
+            json=None,
+        )
+
     def test_get_count_no_filters(self):
         test_obj = Request(
             http_session=Mock(), base="http://localhost:8001/api/dcim/devices",
@@ -53,6 +80,25 @@ class RequestTestCase(unittest.TestCase):
         self.assertEqual(test, 42)
         test_obj.http_session.get.assert_called_with(
             "http://localhost:8001/api/dcim/devices/",
+            params={"limit": 1},
+            headers={"accept": "application/json;"},
+            json=None,
+        )
+    def test_get_count_no_filters_behind_external_proxy(self):
+        test_obj = Request(
+            http_session=Mock(), base="http://example.com/netbox/api/dcim/devices",
+        )
+        test_obj.http_session.get.return_value.json.return_value = {
+            "count": 42,
+            "next": "http://localhost:8001/api/dcim/devices?limit=1&offset=1",
+            "previous": False,
+            "results": [],
+        }
+        test_obj.http_session.get.ok = True
+        test = test_obj.get_count()
+        self.assertEqual(test, 42)
+        test_obj.http_session.get.assert_called_with(
+            "http://example.com/netbox/api/dcim/devices/",
             params={"limit": 1},
             headers={"accept": "application/json;"},
             json=None,

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -19,7 +19,7 @@ class RequestTestCase(unittest.TestCase):
         )
         test_obj.http_session.get.return_value.json.return_value = {
             "count": 42,
-            "next": "http://localhost:8001/api/dcim/devices?limit=1&offset=1&q=abcd",
+            "next": "http://localhost:8001/api/dcim/devices/?limit=1&offset=1&q=abcd",
             "previous": False,
             "results": [],
         }
@@ -33,33 +33,6 @@ class RequestTestCase(unittest.TestCase):
         self.assertEqual(test, 42)
         test_obj.http_session.get.assert_called_with(
             "http://localhost:8001/api/dcim/devices/",
-            params={"q": "abcd", "limit": 1},
-            headers={"accept": "application/json;"},
-            json=None,
-        )
-
-    def test_get_count_behind_external_proxy(self):
-        test_obj = Request(
-            http_session=Mock(),
-            base="http://example.com/netbox/api/dcim/devices",
-            filters={"q": "abcd"},
-        )
-        test_obj.http_session.get.return_value.json.return_value = {
-            "count": 42,
-            "next": "http://localhost:8001/api/dcim/devices?limit=1&offset=1&q=abcd",
-            "previous": False,
-            "results": [],
-        }
-        expected = call(
-            "http://localhost:8001/api/dcim/devices/",
-            params={"q": "abcd", "limit": 1},
-            headers={"accept": "application/json;"},
-        )
-        test_obj.http_session.get.ok = True
-        test = test_obj.get_count()
-        self.assertEqual(test, 42)
-        test_obj.http_session.get.assert_called_with(
-            "http://example.com/netbox/api/dcim/devices/",
             params={"q": "abcd", "limit": 1},
             headers={"accept": "application/json;"},
             json=None,
@@ -71,7 +44,7 @@ class RequestTestCase(unittest.TestCase):
         )
         test_obj.http_session.get.return_value.json.return_value = {
             "count": 42,
-            "next": "http://localhost:8001/api/dcim/devices?limit=1&offset=1",
+            "next": "http://localhost:8001/api/dcim/devices/?limit=1&offset=1",
             "previous": False,
             "results": [],
         }
@@ -84,22 +57,141 @@ class RequestTestCase(unittest.TestCase):
             headers={"accept": "application/json;"},
             json=None,
         )
-    def test_get_count_no_filters_behind_external_proxy(self):
+
+    def test_pagination(self):
         test_obj = Request(
-            http_session=Mock(), base="http://example.com/netbox/api/dcim/devices",
+            http_session=Mock(),
+            base="http://localhost:8001/api/dcim/devices/",
+            limit=2,
+            external_proxy=False
         )
+
         test_obj.http_session.get.return_value.json.return_value = {
-            "count": 42,
-            "next": "http://localhost:8001/api/dcim/devices?limit=1&offset=1",
-            "previous": False,
-            "results": [],
+            "count": 6,
+            "next": "http://localhost:8001/api/dcim/devices/?limit=2&offset=2",
+            "previous": None,
+            "results": [
+                {'id': 87861, 'url': 'https://localhost:8001/api/dcim/devices/87861/', 'name': 'test87861'},
+                {'id': 87862, 'url': 'https://localhost:8001/api/dcim/devices/87862/', 'name': 'test87862'},
+                ],
         }
-        test_obj.http_session.get.ok = True
-        test = test_obj.get_count()
-        self.assertEqual(test, 42)
+        test = test_obj.get()
+        req = next(test)
+        test_obj.http_session.get.assert_called_with(
+            "http://localhost:8001/api/dcim/devices/",
+            headers={"accept": "application/json;"},
+            params={"limit": 2},
+            json=None,
+        )
+        self.assertEqual(req, {'id': 87861, 'url': 'https://localhost:8001/api/dcim/devices/87861/', 'name': 'test87861'})
+        req = next(test)
+        self.assertEqual(req, {'id': 87862, 'url': 'https://localhost:8001/api/dcim/devices/87862/', 'name': 'test87862'})
+
+        test_obj.http_session.get.return_value.json.return_value = {
+            "count": 2,
+            "next": "http://localhost:8001/api/dcim/devices/?limit=2&offset=4",
+            "previous": "http://localhost:8001/api/dcim/devices/?limit=2",
+            "results": [
+                {'id': 87863, 'url': 'https://localhost:8001/api/dcim/devices/87863/', 'name': 'test87863'},
+                {'id': 87864, 'url': 'https://localhost:8001/api/dcim/devices/87864/', 'name': 'test87864'},
+                ],
+        }
+        req = next(test)
+        test_obj.http_session.get.assert_called_with(
+            "http://localhost:8001/api/dcim/devices/",
+            headers={"accept": "application/json;"},
+            params={"limit": 2, "offset": 2},
+            json=None,
+        )
+        self.assertEqual(req, {'id': 87863, 'url': 'https://localhost:8001/api/dcim/devices/87863/', 'name': 'test87863'})
+        req = next(test)
+        self.assertEqual(req, {'id': 87864, 'url': 'https://localhost:8001/api/dcim/devices/87864/', 'name': 'test87864'})
+
+        test_obj.http_session.get.return_value.json.return_value = {
+            "count": 2,
+            "next": None,
+            "previous": "http://localhost:8001/api/dcim/devices/?limit=2&offset=4",
+            "results": [
+                {'id': 87865, 'url': 'https://localhost:8001/api/dcim/devices/87865/', 'name': 'test87865'},
+                {'id': 87866, 'url': 'https://localhost:8001/api/dcim/devices/87866/', 'name': 'test87866'},
+                ],
+        }
+        req = next(test)
+        test_obj.http_session.get.assert_called_with(
+            "http://localhost:8001/api/dcim/devices/?limit=2&offset=4",
+            headers={"accept": "application/json;"},
+            params={},
+            json=None,
+        )
+        self.assertEqual(req, {'id': 87865, 'url': 'https://localhost:8001/api/dcim/devices/87865/', 'name': 'test87865'})
+        req = next(test)
+        self.assertEqual(req, {'id': 87866, 'url': 'https://localhost:8001/api/dcim/devices/87866/', 'name': 'test87866'})
+
+    def test_pagination_behind_external_proxy(self):
+        test_obj = Request(
+            http_session=Mock(),
+            base="http://example.com/netbox/api/dcim/devices",
+            limit=2,
+            external_proxy=True,
+        )
+
+        test_obj.http_session.get.return_value.json.return_value = {
+            "count": 6,
+            "next": "http://localhost:8001/api/dcim/devices/?limit=2&offset=2",
+            "previous": None,
+            "results": [
+                {'id': 87861, 'url': 'https://localhost:8001/api/dcim/devices/87861/', 'name': 'test87861'},
+                {'id': 87862, 'url': 'https://localhost:8001/api/dcim/devices/87862/', 'name': 'test87862'},
+                ],
+        }
+        test = test_obj.get()
+        req = next(test)
         test_obj.http_session.get.assert_called_with(
             "http://example.com/netbox/api/dcim/devices/",
-            params={"limit": 1},
+            headers={"accept": "application/json;"},
+            params={"limit": 2},
+            json=None,
+        )
+        self.assertEqual(req, {'id': 87861, 'url': 'https://localhost:8001/api/dcim/devices/87861/', 'name': 'test87861'})
+        req = next(test)
+        self.assertEqual(req, {'id': 87862, 'url': 'https://localhost:8001/api/dcim/devices/87862/', 'name': 'test87862'})
+
+        test_obj.http_session.get.return_value.json.return_value = {
+            "count": 2,
+            "next": "http://localhost:8001/api/dcim/devices/?limit=2&offset=4",
+            "previous": "http://localhost:8001/api/dcim/devices/?limit=2",
+            "results": [
+                {'id': 87863, 'url': 'https://localhost:8001/api/dcim/devices/87863/', 'name': 'test87863'},
+                {'id': 87864, 'url': 'https://localhost:8001/api/dcim/devices/87864/', 'name': 'test87864'},
+                ],
+        }
+        req = next(test)
+        test_obj.http_session.get.assert_called_with(
+            "http://example.com/netbox/api/dcim/devices/",
+            params={"limit": 2, "offset": 2},
             headers={"accept": "application/json;"},
             json=None,
         )
+        self.assertEqual(req, {'id': 87863, 'url': 'https://localhost:8001/api/dcim/devices/87863/', 'name': 'test87863'})
+        req = next(test)
+        self.assertEqual(req, {'id': 87864, 'url': 'https://localhost:8001/api/dcim/devices/87864/', 'name': 'test87864'})
+
+        test_obj.http_session.get.return_value.json.return_value = {
+            "count": 2,
+            "next": None,
+            "previous": "http://localhost:8001/api/dcim/devices/?limit=2&offset=4",
+            "results": [
+                {'id': 87865, 'url': 'https://localhost:8001/api/dcim/devices/87865/', 'name': 'test87865'},
+                {'id': 87866, 'url': 'https://localhost:8001/api/dcim/devices/87866/', 'name': 'test87866'},
+                ],
+        }
+        req = next(test)
+        test_obj.http_session.get.assert_called_with(
+            "http://example.com/netbox/api/dcim/devices/?limit=2&offset=4",
+            headers={"accept": "application/json;"},
+            params={},
+            json=None,
+        )
+        self.assertEqual(req, {'id': 87865, 'url': 'https://localhost:8001/api/dcim/devices/87865/', 'name': 'test87865'})
+        req = next(test)
+        self.assertEqual(req, {'id': 87866, 'url': 'https://localhost:8001/api/dcim/devices/87866/', 'name': 'test87866'})

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -214,9 +214,10 @@ class RecordTestCase(unittest.TestCase):
         self.assertEqual(test1, test2)
 
     def test_nested_write(self):
-        app = Mock()
-        app.token = "abc123"
-        app.base_url = "http://localhost:8080/api"
+        api = Mock()
+        api.token = "abc123"
+        api.base_url = "http://localhost:8080/api"
+        api.external_proxy = False
         endpoint = Mock()
         endpoint.name = "test-endpoint"
         test = Record(
@@ -229,20 +230,21 @@ class RecordTestCase(unittest.TestCase):
                     "url": "http://localhost:8080/api/test-app/test-endpoint/321/",
                 },
             },
-            app,
+            api,
             endpoint,
         )
         test.child.name = "test321"
         test.child.save()
         self.assertEqual(
-            app.http_session.patch.call_args[0][0],
+            api.http_session.patch.call_args[0][0],
             "http://localhost:8080/api/test-app/test-endpoint/321/",
         )
 
     def test_nested_write_behind_external_proxy(self):
-        app = Mock()
-        app.token = "abc123"
-        app.base_url = "http://example.com/netbox/api"
+        api = Mock()
+        api.token = "abc123"
+        api.base_url = "http://example.com/netbox/api"
+        api.external_proxy = True
         endpoint = Mock()
         endpoint.name = "test-endpoint"
         test = Record(
@@ -255,20 +257,21 @@ class RecordTestCase(unittest.TestCase):
                     "url": "http://localhost:8080/api/test-app/test-endpoint/321/",
                 },
             },
-            app,
+            api,
             endpoint,
         )
         test.child.name = "test321"
         test.child.save()
         self.assertEqual(
-            app.http_session.patch.call_args[0][0],
+            api.http_session.patch.call_args[0][0],
             "http://example.com/netbox/api/test-app/test-endpoint/321/",
         )
 
     def test_nested_write_with_directory_in_base_url(self):
-        app = Mock()
-        app.token = "abc123"
-        app.base_url = "http://localhost:8080/testing/api"
+        api = Mock()
+        api.token = "abc123"
+        api.base_url = "http://localhost:8080/testing/api"
+        api.external_proxy = False
         endpoint = Mock()
         endpoint.name = "test-endpoint"
         test = Record(
@@ -281,20 +284,21 @@ class RecordTestCase(unittest.TestCase):
                     "url": "http://localhost:8080/testing/api/test-app/test-endpoint/321/",
                 },
             },
-            app,
+            api,
             endpoint,
         )
         test.child.name = "test321"
         test.child.save()
         self.assertEqual(
-            app.http_session.patch.call_args[0][0],
+            api.http_session.patch.call_args[0][0],
             "http://localhost:8080/testing/api/test-app/test-endpoint/321/",
         )
 
     def test_nested_write_with_directory_in_base_url_behind_external_proxy(self):
-        app = Mock()
-        app.token = "abc123"
-        app.base_url = "http://example.com/netbox/testing/api"
+        api = Mock()
+        api.token = "abc123"
+        api.base_url = "http://example.com/netbox/testing/api"
+        api.external_proxy = True
         endpoint = Mock()
         endpoint.name = "test-endpoint"
         test = Record(
@@ -307,19 +311,20 @@ class RecordTestCase(unittest.TestCase):
                     "url": "http://localhost:8080/testing/api/test-app/test-endpoint/321/",
                 },
             },
-            app,
+            api,
             endpoint,
         )
         test.child.name = "test321"
         test.child.save()
         self.assertEqual(
-            app.http_session.patch.call_args[0][0],
+            api.http_session.patch.call_args[0][0],
             "http://example.com/netbox/testing/api/test-app/test-endpoint/321/",
         )
 
     def test_endpoint_from_url(self):
         api = Mock()
         api.base_url = "http://localhost:8080/api"
+        api.external_proxy = False
         test = Record(
             {
                 "id": 123,
@@ -335,6 +340,7 @@ class RecordTestCase(unittest.TestCase):
     def test_endpoint_from_url_behind_external_proxy(self):
         api = Mock()
         api.base_url = "http://example.com/netbox/api"
+        api.external_proxy = True
         test = Record(
             {
                 "id": 123,
@@ -350,6 +356,7 @@ class RecordTestCase(unittest.TestCase):
     def test_endpoint_from_url_with_directory_in_base_url(self):
         api = Mock()
         api.base_url = "http://localhost:8080/testing/api"
+        api.external_proxy = False
         test = Record(
             {
                 "id": 123,
@@ -365,6 +372,7 @@ class RecordTestCase(unittest.TestCase):
     def test_endpoint_from_url_with_directory_in_base_url_behind_external_proxy(self):
         api = Mock()
         api.base_url = "http://example.com/netbox/testing/api"
+        api.external_proxy = True
         test = Record(
             {
                 "id": 123,
@@ -380,6 +388,7 @@ class RecordTestCase(unittest.TestCase):
     def test_endpoint_from_url_with_plugins(self):
         api = Mock()
         api.base_url = "http://localhost:8080/api"
+        api.external_proxy = False
         test = Record(
             {
                 "id": 123,
@@ -395,6 +404,7 @@ class RecordTestCase(unittest.TestCase):
     def test_endpoint_from_url_with_plugins_behind_external_proxy(self):
         api = Mock()
         api.base_url = "http://example.com/netbox/api"
+        api.external_proxy = True
         test = Record(
             {
                 "id": 123,
@@ -410,6 +420,7 @@ class RecordTestCase(unittest.TestCase):
     def test_endpoint_from_url_with_plugins_and_directory_in_base_url(self):
         api = Mock()
         api.base_url = "http://localhost:8080/testing/api"
+        api.external_proxy = False
         test = Record(
             {
                 "id": 123,
@@ -425,6 +436,7 @@ class RecordTestCase(unittest.TestCase):
     def test_endpoint_from_url_with_plugins_and_directory_in_base_url_behind_external_proxy(self):
         api = Mock()
         api.base_url = "http://example.com/testing/api"
+        api.external_proxy = True
         test = Record(
             {
                 "id": 123,

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -239,6 +239,32 @@ class RecordTestCase(unittest.TestCase):
             "http://localhost:8080/api/test-app/test-endpoint/321/",
         )
 
+    def test_nested_write_behind_external_proxy(self):
+        app = Mock()
+        app.token = "abc123"
+        app.base_url = "http://example.com/netbox/api"
+        endpoint = Mock()
+        endpoint.name = "test-endpoint"
+        test = Record(
+            {
+                "id": 123,
+                "name": "test",
+                "child": {
+                    "id": 321,
+                    "name": "test123",
+                    "url": "http://localhost:8080/api/test-app/test-endpoint/321/",
+                },
+            },
+            app,
+            endpoint,
+        )
+        test.child.name = "test321"
+        test.child.save()
+        self.assertEqual(
+            app.http_session.patch.call_args[0][0],
+            "http://example.com/netbox/api/test-app/test-endpoint/321/",
+        )
+
     def test_nested_write_with_directory_in_base_url(self):
         app = Mock()
         app.token = "abc123"
@@ -265,9 +291,50 @@ class RecordTestCase(unittest.TestCase):
             "http://localhost:8080/testing/api/test-app/test-endpoint/321/",
         )
 
+    def test_nested_write_with_directory_in_base_url_behind_external_proxy(self):
+        app = Mock()
+        app.token = "abc123"
+        app.base_url = "http://example.com/netbox/testing/api"
+        endpoint = Mock()
+        endpoint.name = "test-endpoint"
+        test = Record(
+            {
+                "id": 123,
+                "name": "test",
+                "child": {
+                    "id": 321,
+                    "name": "test123",
+                    "url": "http://localhost:8080/testing/api/test-app/test-endpoint/321/",
+                },
+            },
+            app,
+            endpoint,
+        )
+        test.child.name = "test321"
+        test.child.save()
+        self.assertEqual(
+            app.http_session.patch.call_args[0][0],
+            "http://example.com/netbox/testing/api/test-app/test-endpoint/321/",
+        )
+
     def test_endpoint_from_url(self):
         api = Mock()
         api.base_url = "http://localhost:8080/api"
+        test = Record(
+            {
+                "id": 123,
+                "name": "test",
+                "url": "http://localhost:8080/api/test-app/test-endpoint/1/",
+            },
+            api,
+            None,
+        )
+        ret = test._endpoint_from_url(test.url)
+        self.assertEqual(ret.name, "test-endpoint")
+
+    def test_endpoint_from_url_behind_external_proxy(self):
+        api = Mock()
+        api.base_url = "http://example.com/netbox/api"
         test = Record(
             {
                 "id": 123,
@@ -295,6 +362,21 @@ class RecordTestCase(unittest.TestCase):
         ret = test._endpoint_from_url(test.url)
         self.assertEqual(ret.name, "test-endpoint")
 
+    def test_endpoint_from_url_with_directory_in_base_url_behind_external_proxy(self):
+        api = Mock()
+        api.base_url = "http://example.com/netbox/testing/api"
+        test = Record(
+            {
+                "id": 123,
+                "name": "test",
+                "url": "http://localhost:8080/testing/api/test-app/test-endpoint/1/",
+            },
+            api,
+            None,
+        )
+        ret = test._endpoint_from_url(test.url)
+        self.assertEqual(ret.name, "test-endpoint")
+
     def test_endpoint_from_url_with_plugins(self):
         api = Mock()
         api.base_url = "http://localhost:8080/api"
@@ -310,9 +392,39 @@ class RecordTestCase(unittest.TestCase):
         ret = test._endpoint_from_url(test.url)
         self.assertEqual(ret.name, "test-endpoint")
 
+    def test_endpoint_from_url_with_plugins_behind_external_proxy(self):
+        api = Mock()
+        api.base_url = "http://example.com/netbox/api"
+        test = Record(
+            {
+                "id": 123,
+                "name": "test",
+                "url": "http://localhost:8080/api/plugins/test-app/test-endpoint/1/",
+            },
+            api,
+            None,
+        )
+        ret = test._endpoint_from_url(test.url)
+        self.assertEqual(ret.name, "test-endpoint")
+
     def test_endpoint_from_url_with_plugins_and_directory_in_base_url(self):
         api = Mock()
         api.base_url = "http://localhost:8080/testing/api"
+        test = Record(
+            {
+                "id": 123,
+                "name": "test",
+                "url": "http://localhost:8080/testing/api/plugins/test-app/test-endpoint/1/",
+            },
+            api,
+            None,
+        )
+        ret = test._endpoint_from_url(test.url)
+        self.assertEqual(ret.name, "test-endpoint")
+
+    def test_endpoint_from_url_with_plugins_and_directory_in_base_url_behind_external_proxy(self):
+        api = Mock()
+        api.base_url = "http://example.com/testing/api"
         test = Record(
             {
                 "id": 123,


### PR DESCRIPTION
Add support for accessing Netbox through an http proxy, where the external base url is in this form:
```
https://proxy.example.com/internal-netbox-instance/api/
```
While continuing to support internal Netbox clients using a base url like this:

```
https://internal-netbox.example.com/api/
```
This PR resolves #376 


It is necessary to set the `external_proxy` flag to true when instantiating the `api()` to enable the url rewriting:
```
base_url = 'https://proxy.example.com/internal-netbox-instance/'
nb = pynetbox.api(base_url, token=token, external_proxy=True)
```
If `external_proxy` is `False` or is unset, the behavior will remain unchanged from previous releases.

When `external_proxy=True`, pynetbox will automatically rewrite urls where necessary, allowing full access to the Netbox API through an http proxy, without needing to reconfigure the Netbox server.  In the `api()` instantiation, `/api/` is appended to `base_url`, so it's value will actually be `https://proxy.example.com/internal-netbox-instance/api/` internally.  

One new feature is that both the host and the path, up to `/api/` will used when rewriting urls, to dynamically support proxies which use a directory structure to represent different services, as well as supporting configurations where there is no additional directory before `/api/`.

This PR will rewrite the `'next'`, `'previous'` and `'url'` fields in the Netbox response data as well, allowing for pagination to work correctly through an http proxy; as well as making it convenient for the user to make requests directly to an object's `'url'` field.

There are two new unit tests to validate that pagination is working, with and without `external_proxy=True` as well as duplicating some of the existing test cases to validate they also work with `external_proxy=True`.