### PR TITLE
Fix object output for `users` in permissions

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -272,7 +272,7 @@ class Record(object):
         return (
             getattr(self, "name", None)
             or getattr(self, "label", None)
-            or getattr(self, "username", None)
+            or getattr(self, "display", None)
             or ""
         )
 

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -269,7 +269,12 @@ class Record(object):
         return dict(self)[k]
 
     def __str__(self):
-        return getattr(self, "name", None) or getattr(self, "label", None) or ""
+        return (
+            getattr(self, "name", None)
+            or getattr(self, "label", None)
+            or getattr(self, "username", None)
+            or ""
+        )
 
     def __repr__(self):
         return str(self)

--- a/tests/fixtures/users/permission.json
+++ b/tests/fixtures/users/permission.json
@@ -1,4 +1,9 @@
 {
     "id": 1,
-    "name": "permission1"
+    "name": "permission1",
+    "users": [
+        {
+            "username": "user1"
+        }
+    ]
 }

--- a/tests/fixtures/users/permission.json
+++ b/tests/fixtures/users/permission.json
@@ -3,6 +3,7 @@
     "name": "permission1",
     "users": [
         {
+            "display": "user1",
             "username": "user1"
         }
     ]

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -95,3 +95,13 @@ class GroupsTestCase(Generic.Tests):
 
 class PermissionsTestCase(Generic.Tests):
     name = "permissions"
+
+    @patch(
+        "requests.sessions.Session.get",
+        return_value=Response(fixture="users/permission.json"),
+    )
+    def test_username(self, _):
+        permission = nb.permissions.get(1)
+        self.assertEqual(len(permission.users), 1)
+        user = permission.users[0]
+        self.assertEqual(str(user), "user1")


### PR DESCRIPTION
The problem:

```
>>> permission = list(netbox.users.permissions.all())[0]
>>> from pprint import pprint as ppr
>>> ppr(dict(permission))
{'actions': ['view'],
 'constraints': None,
 'description': '',
 'display': 'ViewSites',
 'enabled': True,
 'groups': [],
 'id': 1,
 'name': 'ViewSites',
 'object_types': ['dcim.site'],
 'url': 'http://netbox-test.lein.io/api/users/permissions/1/',
 'users': [{'display': 'test1',
            'id': 2,
            'url': 'http://netbox-test.lein.io/api/users/users/2/',
            'username': 'test1'}]}
>>> permission.users
[]
>>>
```
Meaning that the username "test1" is shown as an empty string. That is because `Record.__str__()` only tries to get fields `name` and `label`, and returns empty string if neither of those is found.

This PR addresses this issue by modifying `Record.__str__()` to also try `username` field when returning the string representation of an object.

After the change:

```
>>> permission.users
[test1]
>>>
```