### PR TITLE
Add Pyright/Pylance directives to prevent complaining about `six` imports

### DIFF
--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     pass
 import json
-from six.moves.urllib.parse import urlencode
+from six.moves.urllib.parse import urlencode  # pyright: reportMissingModuleSource=false
 
 
 def calc_pages(limit, count):

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -17,7 +17,7 @@ import copy
 from collections import OrderedDict
 
 import pynetbox.core.app
-from six.moves.urllib.parse import urlsplit
+from six.moves.urllib.parse import urlsplit  # pyright: reportMissingModuleSource=false
 from pynetbox.core.query import Request, RequestError
 from pynetbox.core.util import Hashabledict
 

--- a/pynetbox/models/dcim.py
+++ b/pynetbox/models/dcim.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from six.moves.urllib.parse import urlsplit
+from six.moves.urllib.parse import urlsplit  # pyright: reportMissingModuleSource=false
 
 from pynetbox.core.query import Request
 from pynetbox.core.response import Record, JsonField


### PR DESCRIPTION
In `pynetbox` 6.0.0 release notes it says "**Ends python 2 support**" but I guess it means just _end of testing with Python 2_ because `six` (a Python 2 and 3 compatibility library) is still there.

The problem is that because `six` is a dynamic library VSCode and the excellent Pylance extension for Python complains "_Import "six.moves.urllib.parse" could not be resolved from source_" all the time, and that is a major distraction while developing `pynetbox` code.

This PR adds `# pyright: reportMissingModuleSource=false` directive in each `six` import lines to give the developer peace of mind and possibility to concentrate on the _real_ problems in the newly written code 😁

@zachmoody Feel free to reject this PR if you want me to submit a PR to remove `six` (and Python 2 compatibility) altogether.