### PR TITLE
Replace underscores in plugin app name with dashes

### DIFF
--- a/pynetbox/core/app.py
+++ b/pynetbox/core/app.py
@@ -161,7 +161,7 @@ class PluginsApp(object):
         self.__dict__.update(d)
 
     def __getattr__(self, name):
-        return App(self.api, "plugins/{}".format(name))
+        return App(self.api, "plugins/{}".format(name.replace("_", "-")))
 
     def installed_plugins(self):
         """ Returns raw response with installed plugins

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -73,3 +73,8 @@ class PluginAppCustomChoicesTestCase(unittest.TestCase):
         plugins = api.plugins.installed_plugins()
         self.assertEqual(len(plugins), 1)
         self.assertEqual(plugins[0]["name"], "test_plugin")
+
+    def test_plugin_app_name(self, *_):
+        api = pynetbox.api(host, **def_kwargs)
+        test_plugin = api.plugins.test_plugin
+        self.assertEqual(test_plugin.name, 'plugins/test-plugin')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -77,4 +77,4 @@ class PluginAppCustomChoicesTestCase(unittest.TestCase):
     def test_plugin_app_name(self, *_):
         api = pynetbox.api(host, **def_kwargs)
         test_plugin = api.plugins.test_plugin
-        self.assertEqual(test_plugin.name, 'plugins/test-plugin')
+        self.assertEqual(test_plugin.name, "plugins/test-plugin")


### PR DESCRIPTION
Ran into this issue with my own plugins, where the plugin name is "-" separated in the URL. This fixes [issue 332](https://github.com/netbox-community/pynetbox/issues/332). 
