### PR TITLE
Fixes #316 bulk update/delete on both Endpoint and RecordSet

### DIFF
--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -245,7 +245,7 @@ class Request(object):
         return url
 
     def _make_call(self, verb="get", url_override=None, add_params=None, data=None):
-        if verb in ("post", "put"):
+        if verb in ("post", "put") or verb == "delete" and data:
             headers = {"Content-Type": "application/json;"}
         else:
             headers = {"accept": "application/json;"}
@@ -386,18 +386,20 @@ class Request(object):
         """
         return self._make_call(verb="post", data=data)
 
-    def delete(self):
+    def delete(self, data=None):
         """Makes DELETE request.
 
         Makes a DELETE request to NetBox's API.
 
+        :param data: (list) Contains a dict that will be turned into a
+            json object and sent to the API.
         Returns:
             True if successful.
 
         Raises:
             RequestError if req.ok doesn't return True.
         """
-        return self._make_call(verb="delete")
+        return self._make_call(verb="delete", data=data)
 
     def patch(self, data):
         """Makes PATCH request.

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -486,7 +486,7 @@ class Record(object):
         >>> x.serial
         u''
         >>> x.serial = '1234'
-        >>> x.get_updates()
+        >>> x.updates()
         {'serial': '1234'}
         >>>
         """

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -71,6 +71,58 @@ class EndPointTestCase(unittest.TestCase):
             test = test_obj.get(name="test")
             self.assertEqual(test.id, 123)
 
+    def test_delete_with_ids(self):
+        with patch(
+            "pynetbox.core.query.Request._make_call", return_value=Mock()
+        ) as mock:
+            ids = [1, 3, 5]
+            mock.return_value = True
+            api = Mock(base_url="http://localhost:8000/api")
+            app = Mock(name="test")
+            test_obj = Endpoint(api, app, "test")
+            test = test_obj.delete(ids)
+            mock.assert_called_with(verb="delete", data=[{"id": i} for i in ids])
+            self.assertTrue(test)
+
+    def test_delete_with_objects(self):
+        with patch(
+            "pynetbox.core.query.Request._make_call", return_value=Mock()
+        ) as mock:
+            from pynetbox.core.response import Record
+
+            ids = [1, 3, 5]
+            mock.return_value = True
+            api = Mock(base_url="http://localhost:8000/api")
+            app = Mock(name="test")
+            test_obj = Endpoint(api, app, "test")
+            objects = [
+                Record({"id": i, "name": "dummy" + str(i)}, api, test_obj) for i in ids
+            ]
+            test = test_obj.delete(objects)
+            mock.assert_called_with(verb="delete", data=[{"id": i} for i in ids])
+            self.assertTrue(test)
+
+    def test_delete_with_recordset(self):
+        with patch(
+            "pynetbox.core.query.Request._make_call", return_value=Mock()
+        ) as mock:
+            from pynetbox.core.response import RecordSet
+
+            ids = [1, 3, 5]
+
+            class FakeRequest:
+                def get(self):
+                    return iter([{"id": i, "name": "dummy" + str(i)} for i in ids])
+
+            mock.return_value = True
+            api = Mock(base_url="http://localhost:8000/api")
+            app = Mock(name="test")
+            test_obj = Endpoint(api, app, "test")
+            recordset = RecordSet(test_obj, FakeRequest())
+            test = test_obj.delete(recordset)
+            mock.assert_called_with(verb="delete", data=[{"id": i} for i in ids])
+            self.assertTrue(test)
+
     def test_get_greater_than_one(self):
         with patch(
             "pynetbox.core.query.Request._make_call", return_value=Mock()
@@ -92,3 +144,46 @@ class EndPointTestCase(unittest.TestCase):
             test_obj = Endpoint(api, app, "test")
             test = test_obj.get(name="test")
             self.assertIsNone(test)
+
+    def test_bulk_update_records(self):
+        with patch(
+            "pynetbox.core.query.Request._make_call", return_value=Mock()
+        ) as mock:
+            from pynetbox.core.response import Record
+
+            ids = [1, 3, 5]
+            mock.return_value = True
+            api = Mock(base_url="http://localhost:8000/api")
+            app = Mock(name="test")
+            test_obj = Endpoint(api, app, "test")
+            objects = [
+                Record(
+                    {"id": i, "name": "dummy" + str(i), "unchanged": "yes"},
+                    api,
+                    test_obj,
+                )
+                for i in ids
+            ]
+            for o in objects:
+                o.name = "fluffy" + str(o.id)
+            mock.return_value = [o.serialize() for o in objects]
+            test = test_obj.update(objects)
+            mock.assert_called_with(
+                verb="patch", data=[{"id": i, "name": "fluffy" + str(i)} for i in ids]
+            )
+            self.assertTrue(test)
+
+    def test_bulk_update_json(self):
+        with patch(
+            "pynetbox.core.query.Request._make_call", return_value=Mock()
+        ) as mock:
+            ids = [1, 3, 5]
+            changes = [{"id": i, "name": "puffy" + str(i)} for i in ids]
+            mock.return_value = True
+            api = Mock(base_url="http://localhost:8000/api")
+            app = Mock(name="test")
+            mock.return_value = changes
+            test_obj = Endpoint(api, app, "test")
+            test = test_obj.update(changes)
+            mock.assert_called_with(verb="patch", data=changes)
+            self.assertTrue(test)


### PR DESCRIPTION
SoW: Add support for bulk updates and delete on Endpoint and RecordSet:
* Endpoint.update accepts one of:
  * list of dicts with id & updated attributes for low level access to the API
  * list of modified Records - unmodified Records are *not* updated and only modified attributes are sent
* Endpoint.delete accepts one of:
  * list of ids (int or numeric strings)
  * list of Records
  * RecordSet
* RecordSet.update accepts kwargs which are set onto its Records and then modifications are passed to its Endpoint
* RecordSet.delete does not accept arguments, and simply leverages the Endpoint.delete method
* Tests added:
  * Endpoint.delete: delete with {ids, Records, RecordSet}
  * Endpoint.update: update with {json, Records}. (list of Records & RecordSet is processed identically)
  * RecordSet.delete: delete (without args)
  * RecordSet.update: update with kwargs
* Added code is _blacked_ :)

  