### PR TITLE
Fixes manual pagination (#412) and argless filter (#386)

### DIFF
--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -22,21 +22,21 @@ class EndPointTestCase(unittest.TestCase):
             test = test_obj.filter(test="test")
             self.assertEqual(len(test), 2)
 
-    def test_filter_empty_kwargs(self):
-
-        api = Mock(base_url="http://localhost:8000/api")
-        app = Mock(name="test")
-        test_obj = Endpoint(api, app, "test")
-        with self.assertRaises(ValueError) as _:
-            test_obj.filter()
-
-    def test_filter_reserved_kwargs(self):
+    def test_filter_invalid_pagination_args(self):
 
         api = Mock(base_url="http://localhost:8000/api")
         app = Mock(name="test")
         test_obj = Endpoint(api, app, "test")
         with self.assertRaises(ValueError) as _:
             test_obj.filter(offset=1)
+
+    def test_all_invalid_pagination_args(self):
+
+        api = Mock(base_url="http://localhost:8000/api")
+        app = Mock(name="test")
+        test_obj = Endpoint(api, app, "test")
+        with self.assertRaises(ValueError) as _:
+            test_obj.all(offset=1)
 
     def test_choices(self):
         with patch("pynetbox.core.query.Request.options", return_value=Mock()) as mock:

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -57,3 +57,31 @@ class RequestTestCase(unittest.TestCase):
             headers={"accept": "application/json;"},
             json=None,
         )
+
+    def test_get_manual_pagination(self):
+        test_obj = Request(
+            http_session=Mock(),
+            base="http://localhost:8001/api/dcim/devices",
+            limit=10,
+            offset=20,
+        )
+        test_obj.http_session.get.return_value.json.return_value = {
+            "count": 4,
+            "next": "http://localhost:8001/api/dcim/devices?limit=10&offset=30",
+            "previous": False,
+            "results": [1, 2, 3, 4],
+        }
+        expected = call(
+            "http://localhost:8001/api/dcim/devices/",
+            params={"offset": 20, "limit": 10},
+            headers={"accept": "application/json;"},
+        )
+        test_obj.http_session.get.ok = True
+        generator = test_obj.get()
+        self.assertEqual(len(list(generator)), 4)
+        test_obj.http_session.get.assert_called_with(
+            "http://localhost:8001/api/dcim/devices/",
+            params={"offset": 20, "limit": 10},
+            headers={"accept": "application/json;"},
+            json=None,
+        )


### PR DESCRIPTION
SoW: Allow manual pagination and no-filter calls to ```Endpoint.filter()``` without breaking existing behaviour

- Endpoint.all() now also accepts ```offset``` which can be used with positive limit values - if not set, it is preexisting behaviour.
- Endpoint.filter() now also accepts ```offset``` which can be used with positive limit values - if not set, it is preexisting behaviour.
- Endpoint.filter() now accepts no filter args, which in practice means identical request as to Endpoint.all()
- Tests added:
  - Request.get: Test manual get (test_query.test_get_manual_pagination)
  - Endpoint.all: Test illegal use of offset with limit=0
  - Endpoint.list: Test illegal use of offset with limit=0
- Tests removed:
  - Endpoint.filter: test_filter_empty_kwargs
  - Endpoint.filter: test_filter_reserved_kwargs
- Added code is blacked :)
- All tests checks out