### PR TITLE
Define Permissions.constraints as JSON field to fix #398

### DIFF
--- a/pynetbox/models/users.py
+++ b/pynetbox/models/users.py
@@ -13,9 +13,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from pynetbox.core.response import Record
+from pynetbox.core.response import Record, JsonField
 
 
 class Users(Record):
     def __str__(self):
         return self.username
+
+
+class Permissions(Record):
+    constraints = JsonField


### PR DESCRIPTION
Fixes #398 

Example:

```
>>> perm = list(netbox.users.permissions.all())[0]
>>> perm
TestPermission
>>> pprint(dict(perm))
{'actions': ['view'],
 'constraints': {'status': 'active'},
 'description': '',
 'display': 'TestPermission',
 'enabled': False,
 'groups': [],
 'id': 1,
 'name': 'TestPermission',
 'object_types': ['circuits.circuit'],
 'url': 'http://netbox31beta.lein.io/api/users/permissions/1/',
 'users': []}
>>> perm.constraints
{'status': 'active'}
>>> perm.constraints = {"status": "test"}
>>> perm.save()
True
>>> perm = list(netbox.users.permissions.all())[0]
>>> perm.constraints
{'status': 'test'}
>>>
```