### PR TITLE
Use `display` field in `Record.__str__()` to support future models

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -313,7 +313,12 @@ class Record(object):
         return dict(self)[k]
 
     def __str__(self):
-        return getattr(self, "name", None) or getattr(self, "label", None) or ""
+        return (
+            getattr(self, "name", None)
+            or getattr(self, "label", None)
+            or getattr(self, "display", None)
+            or ""
+        )
 
     def __repr__(self):
         return str(self)

--- a/tests/fixtures/users/unknown_model.json
+++ b/tests/fixtures/users/unknown_model.json
@@ -1,0 +1,4 @@
+{
+    "id": 1,
+    "display": "Unknown object"
+}

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -86,6 +86,7 @@ class UsersTestCase(Generic.Tests):
     )
     def test_repr(self, _):
         test = nb.users.get(1)
+        self.assertEqual(type(test), pynetbox.models.users.Users)
         self.assertEqual(str(test), "user1")
 
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -105,3 +105,19 @@ class PermissionsTestCase(Generic.Tests):
         self.assertEqual(len(permission.users), 1)
         user = permission.users[0]
         self.assertEqual(str(user), "user1")
+
+
+class UnknownModelTestCase(unittest.TestCase):
+    """ This test validates that an unknown model is returned as Record object
+    and that the __str__() method correctly uses the 'display' field of the
+    object (introduced as a standard field in NetBox 2.11.0).
+    """
+
+    @patch(
+        "requests.sessions.Session.get",
+        return_value=Response(fixture="users/unknown_model.json"),
+    )
+    def test_unknown_model(self, _):
+        unknown_obj = nb.unknown_model.get(1)
+        self.assertEqual(type(unknown_obj), pynetbox.core.response.Record)
+        self.assertEqual(str(unknown_obj), "Unknown object")


### PR DESCRIPTION
This PR supersedes #388 for clarity, and should fix #417, example:

```
>>> ss = list(netbox.ipam.services.all())
>>> ss[0].ipaddresses
[1.1.1.1/32]
>>>
```

See also: https://github.com/netbox-community/netbox/pull/5992 (= NetBox 2.11.0 added the `display` fields)