### PR TITLE
Fixes #422: Adds support for HTTP 409 when allocation is unsuccessful

### DIFF
--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -268,7 +268,7 @@ class Request(object):
             url_override or self.url, headers=headers, params=params, json=data
         )
 
-        if req.status_code == 204 and verb == "post":
+        if req.status_code in [204, 409] and verb == "post":
             raise AllocationError(req)
         if verb == "delete":
             if req.ok:

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -73,7 +73,8 @@ class AllocationError(Exception):
     """Allocation Exception
 
     Used with available-ips/available-prefixes when there is no
-    room for allocation and NetBox returns 204 No Content.
+    room for allocation and NetBox returns 204 No Content (before
+    NetBox 3.1.1) or 409 Conflict (since NetBox 3.1.1+).
     """
 
     def __init__(self, message):

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -2,14 +2,12 @@ import unittest
 
 import six
 
-import pynetbox
-from pynetbox.core.query import AllocationError, Request
-from ..util import Response
+from pynetbox.core.query import Request
 
 if six.PY3:
-    from unittest.mock import patch, Mock, call
+    from unittest.mock import Mock, call
 else:
-    from mock import patch, Mock, call
+    from mock import Mock, call
 
 
 class RequestTestCase(unittest.TestCase):
@@ -87,29 +85,3 @@ class RequestTestCase(unittest.TestCase):
             headers={"accept": "application/json;"},
             json=None,
         )
-
-
-class AllocationErrorTestCase(unittest.TestCase):
-    @patch(
-        "requests.sessions.Session.get",
-        return_value=Response(fixture="ipam/prefix.json"),
-    )
-    @patch(
-        "requests.sessions.Session.post", return_value=Response(status_code=204),
-    )
-    def test_204_case(self, _, __):
-        nb = pynetbox.api("http://localhost:8000/")
-        with self.assertRaises(AllocationError):
-            _ = nb.ipam.prefixes.get(1).available_ips.create()
-
-    @patch(
-        "requests.sessions.Session.get",
-        return_value=Response(fixture="ipam/prefix.json"),
-    )
-    @patch(
-        "requests.sessions.Session.post", return_value=Response(status_code=409),
-    )
-    def test_409_case(self, _, __):
-        nb = pynetbox.api("http://localhost:8000/")
-        with self.assertRaises(AllocationError):
-            _ = nb.ipam.prefixes.get(1).available_ips.create()

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -2,7 +2,9 @@ import unittest
 
 import six
 
-from pynetbox.core.query import Request
+import pynetbox
+from pynetbox.core.query import AllocationError, Request
+from ..util import Response
 
 if six.PY3:
     from unittest.mock import patch, Mock, call
@@ -85,3 +87,29 @@ class RequestTestCase(unittest.TestCase):
             headers={"accept": "application/json;"},
             json=None,
         )
+
+
+class AllocationErrorTestCase(unittest.TestCase):
+    @patch(
+        "requests.sessions.Session.get",
+        return_value=Response(fixture="ipam/prefix.json"),
+    )
+    @patch(
+        "requests.sessions.Session.post", return_value=Response(status_code=204),
+    )
+    def test_204_case(self, _, __):
+        nb = pynetbox.api("http://localhost:8000/")
+        with self.assertRaises(AllocationError):
+            _ = nb.ipam.prefixes.get(1).available_ips.create()
+
+    @patch(
+        "requests.sessions.Session.get",
+        return_value=Response(fixture="ipam/prefix.json"),
+    )
+    @patch(
+        "requests.sessions.Session.post", return_value=Response(status_code=409),
+    )
+    def test_409_case(self, _, __):
+        nb = pynetbox.api("http://localhost:8000/")
+        with self.assertRaises(AllocationError):
+            _ = nb.ipam.prefixes.get(1).available_ips.create()

--- a/tests/util.py
+++ b/tests/util.py
@@ -8,6 +8,8 @@ class Response(object):
         self.ok = ok
 
     def load_fixture(self, path):
+        if not path:
+            return ""
         with open("tests/fixtures/{}".format(path), "r") as f:
             return f.read()
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,19 +1,13 @@
 import json
-from unittest.mock import Mock
 
 
 class Response(object):
     def __init__(self, fixture=None, status_code=200, ok=True, content=None):
         self.status_code = status_code
         self.content = json.dumps(content) if content else self.load_fixture(fixture)
-        self.request = Mock()
-        self.request.body = ""
-        self.url = "http://localhost:8000/"
         self.ok = ok
 
     def load_fixture(self, path):
-        if not path:
-            return ""
         with open("tests/fixtures/{}".format(path), "r") as f:
             return f.read()
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,10 +1,14 @@
 import json
+from unittest.mock import Mock
 
 
 class Response(object):
     def __init__(self, fixture=None, status_code=200, ok=True, content=None):
         self.status_code = status_code
         self.content = json.dumps(content) if content else self.load_fixture(fixture)
+        self.request = Mock()
+        self.request.body = ""
+        self.url = "http://localhost:8000/"
         self.ok = ok
 
     def load_fixture(self, path):


### PR DESCRIPTION
HTTP status code 204 (No Content) for a POST request previously raised `AllocationError`, in practice in situations where `/prefixes/xx/available-ips/` or `/prefixes/xx/available-prefixes/` was attempted in NetBox to allocate new IP(s) or prefix(es) but there was no space for the allocation.

As mentioned in #422 NetBox 3.1.1 will return 409 (Conflict) instead in that situation, so this PR adds support for that: both 204 and 409 for a POST request will raise `AllocationError` in `pynetbox`.

AFAIK NetBox will not return 409 for a POST request in any other situations.

`tests.util.Response` class was also changed to make it possible for `AllocationError` to parse required fields from the patched response.

Fixes #422 