### PR TITLE
Set ObjectChanges.postchange_data and .prechange_data to JsonField

### DIFF
--- a/pynetbox/models/extras.py
+++ b/pynetbox/models/extras.py
@@ -22,6 +22,8 @@ class ConfigContexts(Record):
 
 class ObjectChanges(Record):
     object_data = JsonField
+    postchange_data = JsonField
+    prechange_data = JsonField
 
     def __str__(self):
         return self.request_id


### PR DESCRIPTION
Before the fix:

```
>>> change = list(netbox.extras.object_changes.filter(changed_object_type="dcim.device"))[0]
>>> change
9170460a-9924-42f9-adb9-6d5173f20d89
>>> change.postchange_data
Router1
>>> type(change.postchange_data)
<class 'pynetbox.core.response.Record'>
>>> type(change)
<class 'pynetbox.models.extras.ObjectChanges'>
>>>
```
i.e. the change data was incorrectly parsed as `Record` object.

After the fix:
```
>>> change = list(netbox.extras.object_changes.filter(changed_object_type="dcim.device"))[0]
>>> change
9170460a-9924-42f9-adb9-6d5173f20d89
>>> type(change.postchange_data)
<class 'dict'>
>>> change.postchange_data
{'face': '', 'name': 'Router1', 'rack': None, 'site': 1, 'tags': [], 'serial': '', 'status': 'active',
'tenant': None, 'cluster': None, 'created': '2021-11-02', 'comments': '',
...
}
>>>
```

