### PR TITLE
Do not skip `plugins` in endpoints URL

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -399,8 +399,8 @@ class Record(object):
             url_path = url_path[len(extra_path) :]
         split_url_path = url_path.split("/")
         if split_url_path[2] == "plugins":
-            # Skip plugins from the path
-            app, name = split_url_path[3:5]
+            app = "plugins/{}".format(split_url_path[3])
+            name = split_url_path[4]
         else:
             app, name = split_url_path[2:4]
         return getattr(pynetbox.core.app.App(self.api, app), name)


### PR DESCRIPTION
Fix an issue introduced by #324.

I’m not sure whether or not this re-introduce the issue reported in #302 but I don’t know how to reproduce it, so please be careful before merging this.

---

Fixes #425