### PR TITLE
Fixes #427: Adds support for `available-vlans` child endpoint for VLAN groups

### DIFF
--- a/docs/IPAM.rst
+++ b/docs/IPAM.rst
@@ -3,3 +3,6 @@ IPAM
 
 .. autoclass:: pynetbox.models.ipam.Prefixes
   :members:
+
+.. autoclass:: pynetbox.models.ipam.VlanGroups
+  :members:

--- a/pynetbox/models/ipam.py
+++ b/pynetbox/models/ipam.py
@@ -101,11 +101,7 @@ class Aggregates(Record):
 
 class Vlans(Record):
     def __str__(self):
-        return (
-            getattr(self, "display", None)
-            or getattr(self, "name", None)
-            or str(self.vid)
-        )
+        return super().__str__(self) or str(self.vid)
 
 
 class VlanGroups(Record):

--- a/pynetbox/models/ipam.py
+++ b/pynetbox/models/ipam.py
@@ -97,3 +97,34 @@ class Prefixes(Record):
 class Aggregates(Record):
     def __str__(self):
         return str(self.prefix)
+
+
+class AvailableVlans(Record):
+    def __str__(self):
+        return str(self.vid)
+
+
+class VlanGroups(Record):
+    @property
+    def available_vlans(self):
+        """ Represents the ``available-vlans`` detail endpoint.
+
+        Returns a DetailEndpoint object that is the interface for
+        viewing and creating VLANs inside a VLAN group.
+
+        Available since NetBox 3.2.0.
+
+        :returns: :py:class:`.DetailEndpoint`
+
+        :Examples:
+
+        >>> vlan_group = nb.ipam.vlan_groups.get(1)
+        >>> vlan_group.available_vlans.list()
+        [10, 11, 12]
+
+        To create a new VLAN:
+
+        >>> vlan_group.available_vlans.create({"name": "NewVLAN"})
+        10
+        """
+        return DetailEndpoint(self, "available-vlans", custom_return=AvailableVlans)

--- a/pynetbox/models/ipam.py
+++ b/pynetbox/models/ipam.py
@@ -129,6 +129,6 @@ class VlanGroups(Record):
         To create a new VLAN:
 
         >>> vlan_group.available_vlans.create({"name": "NewVLAN"})
-        10
+        NewVLAN (10)
         """
         return DetailEndpoint(self, "available-vlans", custom_return=Vlans)

--- a/pynetbox/models/ipam.py
+++ b/pynetbox/models/ipam.py
@@ -99,9 +99,13 @@ class Aggregates(Record):
         return str(self.prefix)
 
 
-class AvailableVlans(Record):
+class Vlans(Record):
     def __str__(self):
-        return str(self.vid)
+        return (
+            getattr(self, "display", None)
+            or getattr(self, "name", None)
+            or str(self.vid)
+        )
 
 
 class VlanGroups(Record):
@@ -127,4 +131,4 @@ class VlanGroups(Record):
         >>> vlan_group.available_vlans.create({"name": "NewVLAN"})
         10
         """
-        return DetailEndpoint(self, "available-vlans", custom_return=AvailableVlans)
+        return DetailEndpoint(self, "available-vlans", custom_return=Vlans)


### PR DESCRIPTION
Fixes #427.

This approach uses `Vlans` model (based on `Record`) that autodetects the suitable string representation (first it tries `display` field present since NetBox 2.11, then the `name` field and finally plain `vid`).

Example:

```
>>> netbox.version
'3.2'
>>> netbox.status()["netbox-version"]
'3.2.0-dev'
>>> vg = netbox.ipam.vlan_groups.get(name="TestGroup")
>>> vg.min_vid, vg.max_vid
(10, 12)
>>> vg.available_vlans.list()
[10, 11, 12]
>>> v = vg.available_vlans.list()[0]
>>> type(v)
<class 'pynetbox.models.ipam.Vlans'>
>>> ppr(dict(v))
{'group': {'display': 'TestGroup',
           'id': 1,
           'name': 'TestGroup',
           'slug': 'testgroup',
           'url': 'http://netbox-future.lein.io/api/ipam/vlan-groups/1/'},
 'vid': 10}
>>>
>>> new_vlan = vg.available_vlans.create({"name": "NewVLAN"})
>>> new_vlan
NewVLAN (10)
>>> type(new_vlan)
<class 'pynetbox.models.ipam.Vlans'>
>>> ppr(dict(new_vlan))
{'created': '2021-12-27',
 'custom_fields': {},
 'description': '',
 'display': 'NewVLAN (10)',
 'group': {'display': 'TestGroup',
           'id': 1,
           'name': 'TestGroup',
           'slug': 'testgroup',
           'url': 'http://netbox-future.lein.io/api/ipam/vlan-groups/1/'},
 'id': 5,
 'last_updated': '2021-12-27T21:46:44.896245+02:00',
 'name': 'NewVLAN',
 'role': None,
 'site': None,
 'status': {'label': 'Active', 'value': 'active'},
 'tags': [],
 'tenant': None,
 'url': 'http://netbox-future.lein.io/api/ipam/vlans/5/',
 'vid': 10}
>>>
```

(This logic is identical to `Prefixes.available_ips.list()`: there the returned models are `IpAddresses` even though it returns partial objects.)