### PR TITLE
Allow use of plugin-secrets-store with Netbox 3.x

### DIFF
--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -32,7 +32,7 @@ class Api(object):
         * dcim
         * ipam
         * circuits
-        * secrets (on NetBox 2.11 and older)
+        * secrets
         * tenancy
         * extras
         * virtualization
@@ -53,8 +53,9 @@ class Api(object):
         wish to connect to.
     :param str token: Your NetBox token.
     :param str,optional private_key_file: The path to your private
-        key file. (Usable only on NetBox 2.11 and older)
-    :param str,optional private_key: Your private key. (Usable only on NetBox 2.11 and older)
+        key file.
+    :param str,optional private_key: Your private key.
+    :param str,optional secrets_provider: Plugin to use instead of built-in secrets.
     :param bool,optional threading: Set to True to use threading in ``.all()``
         and ``.filter()`` requests.
     :raises ValueError: If *private_key* and *private_key_file* are both
@@ -78,6 +79,7 @@ class Api(object):
         private_key=None,
         private_key_file=None,
         threading=False,
+        secrets_provider=None,
     ):
         if private_key and private_key_file:
             raise ValueError(
@@ -87,6 +89,7 @@ class Api(object):
         self.token = token
         self.private_key = private_key
         self.private_key_file = private_key_file
+        self.secrets_provider = secrets_provider
         self.base_url = base_url
         self.session_key = None
         self.http_session = requests.Session()

--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -107,7 +107,10 @@ class Api(object):
         self.dcim = App(self, "dcim")
         self.ipam = App(self, "ipam")
         self.circuits = App(self, "circuits")
-        self.secrets = App(self, "secrets")
+        if self.secrets_provider is not None:
+            self.secrets = PluginsApp(self)[self.secrets_provider]
+        else:
+            self.secrets = App(self, "secrets")
         self.tenancy = App(self, "tenancy")
         self.extras = App(self, "extras")
         self.virtualization = App(self, "virtualization")

--- a/pynetbox/core/app.py
+++ b/pynetbox/core/app.py
@@ -76,7 +76,7 @@ class App(object):
                 token=self.api.token,
                 private_key=self.api.private_key,
                 http_session=self.api.http_session,
-            ).get_session_key()
+            ).get_session_key(provider=self.api.secrets_provider)
 
     def choices(self):
         """Returns _choices response from App

--- a/pynetbox/core/app.py
+++ b/pynetbox/core/app.py
@@ -162,6 +162,9 @@ class PluginsApp(object):
     Basically valid plugins api could be handled by same App class,
     but you need to add plugins to request url path.
 
+    If the plugin name includes an underscore, it can be accessed using the
+    dict access syntax.
+
     :returns: :py:class:`.App` with added plugins into path.
 
     """
@@ -174,6 +177,9 @@ class PluginsApp(object):
 
     def __setstate__(self, d):
         self.__dict__.update(d)
+
+    def __getitem__(self, name):
+        return App(self.api, "plugins/{}".format(name))
 
     def __getattr__(self, name):
         return App(self.api, "plugins/{}".format(name.replace("_", "-")))

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -209,9 +209,13 @@ class Request(object):
         :param provider: (str, optional) Plugin to use instead of built-in secrets.
         :Returns: String containing session key.
         """
-        session_provider = "secrets" if provider is None else "plugins/{}".format(provider)
+        session_provider = (
+            "secrets" if provider is None else "plugins/{}".format(provider)
+        )
         req = self.http_session.post(
-            "{}{}/get-session-key/?preserve_key=True".format(self.base, session_provider),
+            "{}{}/get-session-key/?preserve_key=True".format(
+                self.base, session_provider
+            ),
             headers={
                 "accept": "application/json",
                 "authorization": "Token {}".format(self.token),

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -200,16 +200,18 @@ class Request(object):
         else:
             raise RequestError(req)
 
-    def get_session_key(self):
+    def get_session_key(self, provider=None):
         """Requests session key
 
         Issues a GET request to the `get-session-key` endpoint for
         subsequent use in requests from the `secrets` endpoint.
 
+        :param provider: (str, optional) Plugin to use instead of built-in secrets.
         :Returns: String containing session key.
         """
+        session_provider = "secrets" if provider is None else "plugins/{}".format(provider)
         req = self.http_session.post(
-            "{}secrets/get-session-key/?preserve_key=True".format(self.base),
+            "{}{}/get-session-key/?preserve_key=True".format(self.base, session_provider),
             headers={
                 "accept": "application/json",
                 "authorization": "Token {}".format(self.token),


### PR DESCRIPTION
currently, `nb.secrets` tries to access Netbox 2.x's built-in secrets store. In version 3.x, a plugin must be used instead; this patch
redirects `nb.secrets` to the plugin provided to `pynetbox.api(secrets_provider=...)`, so scripts using pynetbox can easily
be written to support both Netbox 2.x and 3.x.
All that is needed is to give the desired secret-store-plugin to pynetbox.api(), e.g.
`nb = pynetbox.api(..., secrets_provider="netbox_secretstore")`
Later, the user can use `nb.secrets.secrets.get(...)` in exactly the same way on either netbox version.

This required the following secondary change:

because pynetbox translates underscores to dashes when accessing attributes, it is not possible to use plugins that have actual
underscores in their URLs. For example, `nb.plugins.plugin_with_underscores` actually queries `plugin-with-underscores` (note the dashes) instead.
This adds a way to access those URLs, by using the following syntax: `nb.plugins['plugin_with_underscores']`

Here's an example how that would look:

```py
import pynetbox

nb = pynetbox.api(
    "https://netbox.example",
    token="...",
    private_key_file="private.key",
    secrets_provider="netbox_secretstore"
)
# automatically detect the correct secretstore based on the secrets_provider:
secret = nb.secrets.secrets.get(device="device01.example", name="username")
print("the username is", secret)

# explicitly accessing the secretstore plugin:
# note that this still needs secrets_provider set, otherwise fetching the session key will fail
nb.plugins['netbox_secretstore'].secrets.get(device="device01.example", name="username")
print("the username is", secret)
# (you wouldn't use this for secrets, but other plugins might profit from this syntax)
```