### PR TITLE
Fix `VirtualChassis.__str__()`, make `VirtualChassis.master` a `Devices` object

### DIFF
--- a/pynetbox/models/dcim.py
+++ b/pynetbox/models/dcim.py
@@ -152,8 +152,7 @@ class RackReservations(Record):
 
 
 class VirtualChassis(Record):
-    def __str__(self):
-        return self.master.display_name
+    master = Devices
 
 
 class RUs(Record):


### PR DESCRIPTION
Fixes #328 (VirtualChassis without master)
Fixes #437 (NetBox 2.11+ does not have `display_name` field anymore)

I don't see a reason why a virtual chassis string representation should consist of the master device name when the virtual chassis has its own name, thus the default behaviour of `Record.__str__()` is enough. **Note: This is a change of behaviour in `pynetbox`.** If that is not desired, then we can check for the master device existence and return the VC name only if master is not found.

I see `VirtualChassis.name` was added and master device was made optional in NetBox 2.9: https://netbox.readthedocs.io/en/stable/release-notes/version-2.9/#named-virtual-chassis-2018

Additionally the `master` attribute is made a `Devices` object.
