### PR TITLE
Upgrade Black to the first non-beta release

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,9 +47,9 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"pynetbox"
-copyright = u"2017, DigitalOcean"
-author = u"Zach Moody"
+project = "pynetbox"
+copyright = "2017, DigitalOcean"
+author = "Zach Moody"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -128,7 +128,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "pynetbox.tex", u"pynetbox Documentation", u"Zach Moody", "manual"),
+    (master_doc, "pynetbox.tex", "pynetbox Documentation", "Zach Moody", "manual"),
 ]
 
 
@@ -136,7 +136,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "pynetbox", u"pynetbox Documentation", [author], 1)]
+man_pages = [(master_doc, "pynetbox", "pynetbox Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -148,7 +148,7 @@ texinfo_documents = [
     (
         master_doc,
         "pynetbox",
-        u"pynetbox Documentation",
+        "pynetbox Documentation",
         author,
         "pynetbox",
         "A python library for NetBox.",

--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -72,7 +72,12 @@ class Api(object):
     """
 
     def __init__(
-        self, url, token=None, private_key=None, private_key_file=None, threading=False,
+        self,
+        url,
+        token=None,
+        private_key=None,
+        private_key_file=None,
+        threading=False,
     ):
         if private_key and private_key_file:
             raise ValueError(
@@ -127,7 +132,8 @@ class Api(object):
         >>>
         """
         version = Request(
-            base=self.base_url, http_session=self.http_session,
+            base=self.base_url,
+            http_session=self.http_session,
         ).get_version()
         return version
 
@@ -149,7 +155,8 @@ class Api(object):
         >>>
         """
         return Request(
-            base=self.base_url, http_session=self.http_session,
+            base=self.base_url,
+            http_session=self.http_session,
         ).get_openapi()
 
     def status(self):
@@ -181,12 +188,14 @@ class Api(object):
         >>>
         """
         status = Request(
-            base=self.base_url, token=self.token, http_session=self.http_session,
+            base=self.base_url,
+            token=self.token,
+            http_session=self.http_session,
         ).get_status()
         return status
 
     def create_token(self, username, password):
-        """ Creates an API token using a valid NetBox username and password.
+        """Creates an API token using a valid NetBox username and password.
         Saves the created token automatically in the API object.
 
         Requires NetBox 3.0.0 or newer.

--- a/pynetbox/core/app.py
+++ b/pynetbox/core/app.py
@@ -27,7 +27,7 @@ from pynetbox.models import (
 
 
 class App(object):
-    """ Represents apps in NetBox.
+    """Represents apps in NetBox.
 
     Calls to attributes are returned as Endpoint objects.
 
@@ -79,7 +79,7 @@ class App(object):
             ).get_session_key()
 
     def choices(self):
-        """ Returns _choices response from App
+        """Returns _choices response from App
 
         .. note::
 
@@ -102,7 +102,7 @@ class App(object):
         return self._choices
 
     def custom_choices(self):
-        """ Returns _custom_field_choices response from app
+        """Returns _custom_field_choices response from app
 
         .. note::
 
@@ -119,7 +119,10 @@ class App(object):
          'Testfield2': {'Othervalue2': 4, 'Othervalue1': 3}}
         """
         custom_field_choices = Request(
-            base="{}/{}/_custom_field_choices/".format(self.api.base_url, self.name,),
+            base="{}/{}/_custom_field_choices/".format(
+                self.api.base_url,
+                self.name,
+            ),
             token=self.api.token,
             private_key=self.api.private_key,
             http_session=self.api.http_session,
@@ -127,7 +130,7 @@ class App(object):
         return custom_field_choices
 
     def config(self):
-        """ Returns config response from app
+        """Returns config response from app
 
         :Returns: Raw response from NetBox's config endpoint.
         :Raises: :py:class:`.RequestError` if called for an invalid endpoint.
@@ -143,7 +146,10 @@ class App(object):
                                                 'tags']}}}
         """
         config = Request(
-            base="{}/{}/config/".format(self.api.base_url, self.name,),
+            base="{}/{}/config/".format(
+                self.api.base_url,
+                self.name,
+            ),
             token=self.api.token,
             private_key=self.api.private_key,
             http_session=self.api.http_session,
@@ -173,22 +179,24 @@ class PluginsApp(object):
         return App(self.api, "plugins/{}".format(name.replace("_", "-")))
 
     def installed_plugins(self):
-        """ Returns raw response with installed plugins
+        """Returns raw response with installed plugins
 
         :returns: Raw response NetBox's installed plugins.
         :Example:
 
         >>> nb.plugins.installed_plugins()
         [{
-            'name': 'test_plugin', 
-            'package': 'test_plugin', 
-            'author': 'Dmitry', 
-            'description': 'Netbox test plugin', 
+            'name': 'test_plugin',
+            'package': 'test_plugin',
+            'author': 'Dmitry',
+            'description': 'Netbox test plugin',
             'verison': '0.10'
         }]
         """
         installed_plugins = Request(
-            base="{}/plugins/installed-plugins".format(self.api.base_url,),
+            base="{}/plugins/installed-plugins".format(
+                self.api.base_url,
+            ),
             token=self.api.token,
             private_key=self.api.private_key,
             http_session=self.api.http_session,

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -48,7 +48,9 @@ class Endpoint(object):
         self.token = api.token
         self.session_key = api.session_key
         self.url = "{base_url}/{app}/{endpoint}".format(
-            base_url=self.base_url, app=app.name, endpoint=self.name,
+            base_url=self.base_url,
+            app=app.name,
+            endpoint=self.name,
         )
         self._choices = None
 
@@ -443,7 +445,7 @@ class Endpoint(object):
         return True if req.delete(data=[{"id": i} for i in cleaned_ids]) else False
 
     def choices(self):
-        """ Returns all choices from the endpoint.
+        """Returns all choices from the endpoint.
 
         The returned dict is also saved in the endpoint object (in
         ``_choices`` attribute) so that later calls will return the same data

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -22,7 +22,7 @@ from six.moves.urllib.parse import urlencode
 
 
 def calc_pages(limit, count):
-    """ Calculate number of pages required for full results set. """
+    """Calculate number of pages required for full results set."""
     return int(count / limit) + (limit % count > 0)
 
 
@@ -165,7 +165,7 @@ class Request(object):
         self.offset = offset
 
     def get_openapi(self):
-        """ Gets the OpenAPI Spec """
+        """Gets the OpenAPI Spec"""
         headers = {
             "Content-Type": "application/json;",
         }
@@ -179,7 +179,7 @@ class Request(object):
             raise RequestError(req)
 
     def get_version(self):
-        """ Gets the API version of NetBox.
+        """Gets the API version of NetBox.
 
         Issues a GET request to the base URL to read the API version from the
         response headers.
@@ -191,7 +191,10 @@ class Request(object):
         headers = {
             "Content-Type": "application/json;",
         }
-        req = self.http_session.get(self.normalize_url(self.base), headers=headers,)
+        req = self.http_session.get(
+            self.normalize_url(self.base),
+            headers=headers,
+        )
         if req.ok:
             return req.headers.get("API-Version", "")
         else:
@@ -223,7 +226,7 @@ class Request(object):
             raise RequestError(req)
 
     def get_status(self):
-        """ Gets the status from /api/status/ endpoint in NetBox.
+        """Gets the status from /api/status/ endpoint in NetBox.
 
         :Returns: Dictionary as returned by NetBox.
         :Raises: RequestError if request is not successful.
@@ -232,7 +235,8 @@ class Request(object):
         if self.token:
             headers["authorization"] = "Token {}".format(self.token)
         req = self.http_session.get(
-            "{}status/".format(self.normalize_url(self.base)), headers=headers,
+            "{}status/".format(self.normalize_url(self.base)),
+            headers=headers,
         )
         if req.ok:
             return req.json()
@@ -240,8 +244,7 @@ class Request(object):
             raise RequestError(req)
 
     def normalize_url(self, url):
-        """ Builds a url for POST actions.
-        """
+        """Builds a url for POST actions."""
         if url[-1] != "/":
             return "{}/".format(url)
 

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -348,7 +348,7 @@ class Record(object):
         self._init_cache.append((key, get_return(value)))
 
     def _parse_values(self, values):
-        """ Parses values init arg.
+        """Parses values init arg.
 
         Parses values dict at init and sets object attributes with the
         values within.

--- a/pynetbox/models/dcim.py
+++ b/pynetbox/models/dcim.py
@@ -54,7 +54,10 @@ class TraceableRecord(Record):
                     .path[len(urlsplit(self.api.base_url).path) :]
                     .split("/")[1:3]
                 )
-                return_obj_class = uri_to_obj_class_map.get(app_endpoint, Record,)
+                return_obj_class = uri_to_obj_class_map.get(
+                    app_endpoint,
+                    Record,
+                )
                 this_hop_ret.append(
                     return_obj_class(hop_item_data, self.endpoint.api, self.endpoint)
                 )
@@ -72,16 +75,16 @@ class DeviceTypes(Record):
 class Devices(Record):
     """Devices Object
 
-        Represents a device response from netbox.
+    Represents a device response from netbox.
 
-        Attributes:
-            primary_ip, ip4, ip6 (list): Tells __init__ in Record() to
-                take the `primary_ip` field's value from the API
-                response and return an initialized list of IpAddress
-                objects
-            device_type (obj): Tells __init__ in Record() to take the
-                `device_type` field's value from the API response and
-                return an initialized DeviceType object
+    Attributes:
+        primary_ip, ip4, ip6 (list): Tells __init__ in Record() to
+            take the `primary_ip` field's value from the API
+            response and return an initialized list of IpAddress
+            objects
+        device_type (obj): Tells __init__ in Record() to take the
+            `device_type` field's value from the API response and
+            return an initialized DeviceType object
     """
 
     has_details = True
@@ -94,7 +97,7 @@ class Devices(Record):
 
     @property
     def napalm(self):
-        """ Represents the ``napalm`` detail endpoint.
+        """Represents the ``napalm`` detail endpoint.
 
         Returns a DetailEndpoint object that is the interface for
         viewing response from the napalm endpoint.
@@ -171,7 +174,7 @@ class RearPorts(TraceableRecord):
 class Racks(Record):
     @property
     def units(self):
-        """ Represents the ``units`` detail endpoint.
+        """Represents the ``units`` detail endpoint.
 
         Returns a DetailEndpoint object that is the interface for
         viewing response from the units endpoint.
@@ -189,7 +192,7 @@ class Racks(Record):
 
     @property
     def elevation(self):
-        """ Represents the ``elevation`` detail endpoint.
+        """Represents the ``elevation`` detail endpoint.
 
         Returns a DetailEndpoint object that is the interface for
         viewing response from the elevation endpoint updated in

--- a/pynetbox/models/ipam.py
+++ b/pynetbox/models/ipam.py
@@ -28,7 +28,7 @@ class Prefixes(Record):
 
     @property
     def available_ips(self):
-        """ Represents the ``available-ips`` detail endpoint.
+        """Represents the ``available-ips`` detail endpoint.
 
         Returns a DetailEndpoint object that is the interface for
         viewing and creating IP addresses inside a prefix.
@@ -59,7 +59,7 @@ class Prefixes(Record):
 
     @property
     def available_prefixes(self):
-        """ Represents the ``available-prefixes`` detail endpoint.
+        """Represents the ``available-prefixes`` detail endpoint.
 
         Returns a DetailEndpoint object that is the interface for
         viewing and creating prefixes inside a parent prefix.
@@ -107,7 +107,7 @@ class Vlans(Record):
 class VlanGroups(Record):
     @property
     def available_vlans(self):
-        """ Represents the ``available-vlans`` detail endpoint.
+        """Represents the ``available-vlans`` detail endpoint.
 
         Returns a DetailEndpoint object that is the interface for
         viewing and creating VLANs inside a VLAN group.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-black==19.10b0
+black==22.1.0
 pytest==6.2.*
 pytest-docker==0.10.*

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-black==22.1.0
+black~=22.0
 pytest==6.2.*
 pytest-docker==0.10.*

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,10 @@ setup(
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
     packages=find_packages(exclude=["tests", "tests.*"]),
-    install_requires=["requests>=2.20.0,<3.0", "six==1.*",],
+    install_requires=[
+        "requests>=2.20.0,<3.0",
+        "six==1.*",
+    ],
     zip_safe=False,
     keywords=["netbox"],
     classifiers=[

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -232,7 +232,9 @@ def docker_compose_file(pytestconfig, netbox_docker_repo_dirpaths):
                 docker_netbox_version,
             )
             compose_data["networks"] = {
-                docker_network_name: {"name": docker_network_name,}
+                docker_network_name: {
+                    "name": docker_network_name,
+                }
             }
 
             # prepend the netbox version to each of the service names and anything else
@@ -265,7 +267,10 @@ def docker_compose_file(pytestconfig, netbox_docker_repo_dirpaths):
                     ]:
                         new_service_dependencies.append(
                             "netbox_v%s_%s"
-                            % (docker_netbox_version, dependent_service_name,)
+                            % (
+                                docker_netbox_version,
+                                dependent_service_name,
+                            )
                         )
                     new_services[new_service_name][
                         "depends_on"
@@ -311,12 +316,17 @@ def docker_compose_file(pytestconfig, netbox_docker_repo_dirpaths):
             for volume_name, volume_config in compose_data["volumes"].items():
                 new_volumes[
                     "%s_v%s_%s"
-                    % (DOCKER_PROJECT_PREFIX, docker_netbox_version, volume_name,)
+                    % (
+                        DOCKER_PROJECT_PREFIX,
+                        docker_netbox_version,
+                        volume_name,
+                    )
                 ] = volume_config
             compose_data["volumes"] = new_volumes
 
             compose_output_fpath = os.path.join(
-                netbox_docker_repo_dirpath, "docker-compose-v%s.yml" % netbox_version,
+                netbox_docker_repo_dirpath,
+                "docker-compose-v%s.yml" % netbox_version,
             )
             with open(compose_output_fpath, "w") as fdesc:
                 fdesc.write(yaml.dump(compose_data))
@@ -358,7 +368,10 @@ def id_netbox_service(fixture_value):
 
 @pytest.fixture(scope="session")
 def docker_netbox_service(
-    pytestconfig, docker_ip, docker_services, request,
+    pytestconfig,
+    docker_ip,
+    docker_services,
+    request,
 ):
     """Get the netbox service to test against.
 
@@ -461,7 +474,9 @@ def device_type(api, manufacturer):
 @pytest.fixture(scope="session")
 def device_role(api):
     device_role = api.dcim.device_roles.create(
-        name="test-device-role", slug="test-device-role", color="000000",
+        name="test-device-role",
+        slug="test-device-role",
+        color="000000",
     )
     yield device_role
     device_role.delete()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -52,10 +52,13 @@ class ApiVersionTestCase(unittest.TestCase):
         ok = True
 
     @patch(
-        "requests.sessions.Session.get", return_value=ResponseHeadersWithVersion(),
+        "requests.sessions.Session.get",
+        return_value=ResponseHeadersWithVersion(),
     )
     def test_api_version(self, *_):
-        api = pynetbox.api(host,)
+        api = pynetbox.api(
+            host,
+        )
         self.assertEqual(api.version, "1.999")
 
     class ResponseHeadersWithoutVersion:
@@ -63,10 +66,13 @@ class ApiVersionTestCase(unittest.TestCase):
         ok = True
 
     @patch(
-        "requests.sessions.Session.get", return_value=ResponseHeadersWithoutVersion(),
+        "requests.sessions.Session.get",
+        return_value=ResponseHeadersWithoutVersion(),
     )
     def test_api_version_not_found(self, *_):
-        api = pynetbox.api(host,)
+        api = pynetbox.api(
+            host,
+        )
         self.assertEqual(api.version, "")
 
 
@@ -80,10 +86,13 @@ class ApiStatusTestCase(unittest.TestCase):
             }
 
     @patch(
-        "requests.sessions.Session.get", return_value=ResponseWithStatus(),
+        "requests.sessions.Session.get",
+        return_value=ResponseWithStatus(),
     )
     def test_api_status(self, *_):
-        api = pynetbox.api(host,)
+        api = pynetbox.api(
+            host,
+        )
         self.assertEqual(api.status()["netbox-version"], "0.9.9")
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -36,7 +36,14 @@ class AppConfigTestCase(unittest.TestCase):
         "pynetbox.core.query.Request.get",
         return_value={
             "tables": {
-                "DeviceTable": {"columns": ["name", "status", "tenant", "tags",],},
+                "DeviceTable": {
+                    "columns": [
+                        "name",
+                        "status",
+                        "tenant",
+                        "tags",
+                    ],
+                },
             },
         },
     )
@@ -66,7 +73,12 @@ class PluginAppCustomChoicesTestCase(unittest.TestCase):
 
     @patch(
         "pynetbox.core.query.Request.get",
-        return_value=[{"name": "test_plugin", "package": "netbox_test_plugin",}],
+        return_value=[
+            {
+                "name": "test_plugin",
+                "package": "netbox_test_plugin",
+            }
+        ],
     )
     def test_installed_plugins(self, *_):
         api = pynetbox.api(host, **def_kwargs)

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -9,7 +9,9 @@ if six.PY3:
 else:
     from mock import patch
 
-api = pynetbox.api("http://localhost:8000",)
+api = pynetbox.api(
+    "http://localhost:8000",
+)
 
 nb = api.circuits
 

--- a/tests/test_tenancy.py
+++ b/tests/test_tenancy.py
@@ -10,7 +10,9 @@ else:
     from mock import patch
 
 
-api = pynetbox.api("http://localhost:8000",)
+api = pynetbox.api(
+    "http://localhost:8000",
+)
 
 nb = api.tenancy
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -10,7 +10,9 @@ else:
     from mock import patch
 
 
-api = pynetbox.api("http://localhost:8000",)
+api = pynetbox.api(
+    "http://localhost:8000",
+)
 
 nb = api.users
 
@@ -109,7 +111,7 @@ class PermissionsTestCase(Generic.Tests):
 
 
 class UnknownModelTestCase(unittest.TestCase):
-    """ This test validates that an unknown model is returned as Record object
+    """This test validates that an unknown model is returned as Record object
     and that the __str__() method correctly uses the 'display' field of the
     object (introduced as a standard field in NetBox 2.11.0).
     """

--- a/tests/test_virtualization.py
+++ b/tests/test_virtualization.py
@@ -10,7 +10,9 @@ else:
     from mock import patch
 
 
-api = pynetbox.api("http://localhost:8000",)
+api = pynetbox.api(
+    "http://localhost:8000",
+)
 
 nb = api.virtualization
 

--- a/tests/unit/test_extras.py
+++ b/tests/unit/test_extras.py
@@ -8,7 +8,11 @@ from pynetbox.models.extras import ConfigContexts
 class ExtrasTestCase(unittest.TestCase):
     def test_config_contexts(self):
         test_values = {
-            "data": {"test_int": 123, "test_str": "testing", "test_list": [1, 2, 3],}
+            "data": {
+                "test_int": 123,
+                "test_str": "testing",
+                "test_list": [1, 2, 3],
+            }
         }
         test = ConfigContexts(test_values, None, None)
         self.assertTrue(test)

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -40,7 +40,8 @@ class RequestTestCase(unittest.TestCase):
 
     def test_get_count_no_filters(self):
         test_obj = Request(
-            http_session=Mock(), base="http://localhost:8001/api/dcim/devices",
+            http_session=Mock(),
+            base="http://localhost:8001/api/dcim/devices",
         )
         test_obj.http_session.get.return_value.json.return_value = {
             "count": 42,

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -81,9 +81,18 @@ class RecordTestCase(unittest.TestCase):
         test_values = {
             "id": 123,
             "tags": [
-                {"id": 1, "name": "foo",},
-                {"id": 2, "name": "bar",},
-                {"id": 3, "name": "baz",},
+                {
+                    "id": 1,
+                    "name": "foo",
+                },
+                {
+                    "id": 2,
+                    "name": "bar",
+                },
+                {
+                    "id": 3,
+                    "name": "baz",
+                },
             ],
         }
         test = Record(test_values, None, None).serialize()
@@ -162,7 +171,10 @@ class RecordTestCase(unittest.TestCase):
     def test_choices_idempotence_prev27(self):
         test_values = {
             "id": 123,
-            "choices_test": {"value": 1, "label": "test",},
+            "choices_test": {
+                "value": 1,
+                "label": "test",
+            },
         }
         test = Record(test_values, None, None)
         test.choices_test = 1
@@ -171,7 +183,11 @@ class RecordTestCase(unittest.TestCase):
     def test_choices_idempotence_v27(self):
         test_values = {
             "id": 123,
-            "choices_test": {"value": "test", "label": "test", "id": 1,},
+            "choices_test": {
+                "value": "test",
+                "label": "test",
+                "id": 1,
+            },
         }
         test = Record(test_values, None, None)
         test.choices_test = "test"
@@ -180,7 +196,10 @@ class RecordTestCase(unittest.TestCase):
     def test_choices_idempotence_v28(self):
         test_values = {
             "id": 123,
-            "choices_test": {"value": "test", "label": "test",},
+            "choices_test": {
+                "value": "test",
+                "label": "test",
+            },
         }
         test = Record(test_values, None, None)
         test.choices_test = "test"


### PR DESCRIPTION
Since Black has been selected to be the code formatter for `pynetbox`, let's upgrade it to the first non-beta release.

`requirements-dev.txt` has been set to `black~=22.0` as per the [Black Stability Policy](https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy).