### PR TITLE
Use devices as variable for example calls to nb.dcim.devices

### DIFF
--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -225,7 +225,7 @@ class Endpoint(object):
         Passing a list as a named argument adds multiple filters of the
         same value.
 
-        >>> device = nb.dcim.devices.filter(role=['leaf-switch', 'spine-switch'])
+        >>> devices = nb.dcim.devices.filter(role=['leaf-switch', 'spine-switch'])
         >>> for device in devices:
         ...     print(device.name)
         ...


### PR DESCRIPTION
When calling nb.dcim.devices in the examples, devices
should be used as a variable.

Signed-off-by: Christian Berendt <berendt@osism.tech>