### PR TITLE
ci: test against the currently supported python versions

### DIFF
--- a/.github/workflows/py3.yml
+++ b/.github/workflows/py3.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.8]
+        python: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/py3.yml
+++ b/.github/workflows/py3.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.10]
+        python: ["3.7", "3.10"]
         netbox: ["2.11", "3.0", "3.1"]
 
     steps:


### PR DESCRIPTION
While working on https://github.com/netbox-community/pynetbox/pull/444 I noticed that python 3.6 was still being tested here while official support of that python version [was dropped in netbox v3.0.0](https://netbox.readthedocs.io/en/stable/#supported-python-versions). 


Once https://github.com/netbox-community/pynetbox/pull/444 is merged I will rebase this one. 