### PR TITLE
Fixes #447: Remove extra self argument in Vlans.__str__()

### DIFF
--- a/pynetbox/models/ipam.py
+++ b/pynetbox/models/ipam.py
@@ -101,7 +101,7 @@ class Aggregates(Record):
 
 class Vlans(Record):
     def __str__(self):
-        return super().__str__(self) or str(self.vid)
+        return super().__str__() or str(self.vid)
 
 
 class VlanGroups(Record):


### PR DESCRIPTION
Fixes #447 

Before this fix:

```
>>> vlan = netbox.ipam.vlans.get(1)
>>> vlan.name
'My VLAN'
>>> vlan
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/markku/devel/pynetbox/pynetbox/core/response.py", line 324, in __repr__
    return str(self)
  File "/home/markku/devel/pynetbox/pynetbox/models/ipam.py", line 104, in __str__
    return super().__str__(self) or str(self.vid)
TypeError: __str__() takes 1 positional argument but 2 were given
```

After this fix:

```
>>> vlan = netbox.ipam.vlans.get(1)
>>> vlan.name
'My VLAN'
>>> vlan
My VLAN
```