### PR TITLE
Fix pickling exception with custom errors

### DIFF
--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -102,7 +102,9 @@ class ContentError(Exception):
         self.req = req
         self.request_body = req.request.body
         self.base = req.url
-        self.error = "The server returned invalid (non-json) data. Maybe not a NetBox server?"
+        self.error = (
+            "The server returned invalid (non-json) data. Maybe not a NetBox server?"
+        )
 
     def __str__(self):
         return self.error

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -43,18 +43,16 @@ class RequestError(Exception):
 
     """
 
-    def __init__(self, message):
-        req = message
-
+    def __init__(self, req):
         if req.status_code == 404:
-            message = "The requested url: {} could not be found.".format(req.url)
+            self.message = "The requested url: {} could not be found.".format(req.url)
         else:
             try:
-                message = "The request failed with code {} {}: {}".format(
+                self.message = "The request failed with code {} {}: {}".format(
                     req.status_code, req.reason, req.json()
                 )
             except ValueError:
-                message = (
+                self.message = (
                     "The request failed with code {} {} but more specific "
                     "details were not returned in json. Check the NetBox Logs "
                     "or investigate this exception's error attribute.".format(
@@ -62,11 +60,14 @@ class RequestError(Exception):
                     )
                 )
 
-        super(RequestError, self).__init__(message)
+        super(RequestError, self).__init__(req)
         self.req = req
         self.request_body = req.request.body
         self.base = req.url
         self.error = req.text
+
+    def __str__(self):
+        return self.message
 
 
 class AllocationError(Exception):
@@ -77,16 +78,15 @@ class AllocationError(Exception):
     NetBox 3.1.1) or 409 Conflict (since NetBox 3.1.1+).
     """
 
-    def __init__(self, message):
-        req = message
-
-        message = "The requested allocation could not be fulfilled."
-
-        super(AllocationError, self).__init__(message)
+    def __init__(self, req):
+        super(AllocationError, self).__init__(req)
         self.req = req
         self.request_body = req.request.body
         self.base = req.url
-        self.error = message
+        self.error = "The requested allocation could not be fulfilled."
+
+    def __str__(self):
+        return self.error
 
 
 class ContentError(Exception):
@@ -97,18 +97,15 @@ class ContentError(Exception):
     exception is raised in those cases.
     """
 
-    def __init__(self, message):
-        req = message
-
-        message = (
-            "The server returned invalid (non-json) data. Maybe not " "a NetBox server?"
-        )
-
-        super(ContentError, self).__init__(message)
+    def __init__(self, req):
+        super(ContentError, self).__init__(req)
         self.req = req
         self.request_body = req.request.body
         self.base = req.url
-        self.error = message
+        self.error = "The server returned invalid (non-json) data. Maybe not a NetBox server?"
+
+    def __str__(self):
+        return self.error
 
 
 class Request(object):


### PR DESCRIPTION
**Description**
I ran into an issue when using pynetbox with the `multiprocessing` module. Using a `Pool`, data is serialized between processes using `pickle`.

In my case, a 502 is returned from time to time by our instance of Netbox, resulting in an exception in pynetbox when building a `RequestError` in one of the processes of the `Pool`. An exception is raised during the unpickle (details below).

**To reproduce**
```python
import pickle

from requests import PreparedRequest, Response
from pynetbox import RequestError

if __name__ == '__main__':
    req = PreparedRequest()
    req.body = 'Bad Gateway'

    resp = Response()
    resp.status_code = 502
    resp.reason = 'Bad Gateway'
    resp.request = req

    pickle.loads(pickle.dumps(RequestError(resp)))
```

**Expected behaviour**
No error.

**Actual behaviour**
```
Traceback (most recent call last):
  File "/Users/eq01458/Development/tmp/python/snippet.py", line 16, in <module>
    pickle.loads(pickle.dumps(RequestError(resp)))
  File "/Users/eq01458/.pyenv/versions/3.10/lib/python3.10/site-packages/pynetbox/core/query.py", line 49, in __init__
    if req.status_code == 404:
AttributeError: 'str' object has no attribute 'status_code'
```

**Fix**
The fix proposed in this PR is:
* Pass along the same request/response object to the base exception constructor
* Implement the `__str__` to get the same behaviour as using the message argument for the base exception