### PR TITLE
CI: Add integration testing for NetBox 3.2

### DIFF
--- a/.github/workflows/py3.yml
+++ b/.github/workflows/py3.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.7", "3.10"]
-        netbox: ["2.11", "3.0", "3.1"]
+        netbox: ["2.11", "3.1", "3.2"]
 
     steps:
       - uses: actions/checkout@v2

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -28,9 +28,9 @@ def get_netbox_docker_version_tag(netbox_version):
     """
     major, minor = netbox_version.major, netbox_version.minor
 
-    if (major, minor) == (3, 1):
-        tag = "1.5.1"
-    elif (major, minor) == (3, 0):
+    if (major, minor) == (3, 2):
+        tag = "1.6.1"
+    elif (major, minor) == (3, 1):
         tag = "1.5.1"
     elif (major, minor) == (2, 11):
         tag = "1.2.0"


### PR DESCRIPTION
At the same time I dropped testing for 3.0, I'm thinking along the lines that testing for 3.1 should represent 3.0 well enough.