### PR TITLE
Update doco for all() and filter() methods regarding iteration over result set

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The first argument the .api() method takes is the NetBox URL. There are a handfu
 The pynetbox API is setup so that NetBox's apps are attributes of the `.api()` object, and in turn those apps have attribute representing each endpoint. Each endpoint has a handful of methods available to carry out actions on the endpoint. For example, in order to query all the objects in the `devices` endpoint you would do the following:
 
 ```
->>> devices = nb.dcim.devices.all()
+>>> devices = list(nb.dcim.devices.all())
 >>> for device in devices:
 ...     print(device.name)
 ...

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The first argument the .api() method takes is the NetBox URL. There are a handfu
 The pynetbox API is setup so that NetBox's apps are attributes of the `.api()` object, and in turn those apps have attribute representing each endpoint. Each endpoint has a handful of methods available to carry out actions on the endpoint. For example, in order to query all the objects in the `devices` endpoint you would do the following:
 
 ```
->>> devices = list(nb.dcim.devices.all())
+>>> devices = nb.dcim.devices.all()
 >>> for device in devices:
 ...     print(device.name)
 ...
@@ -40,6 +40,11 @@ test1-leaf1
 test1-leaf2
 test1-leaf3
 >>>
+```
+
+Note that the all() and filter() methods are generators and return an object that can be iterated over only once.  If you are going to be iterating over it repeatedly you need to either call the all() method again, or encapsulate the results in a `list` object like this:
+```
+>>> devices = list(nb.dcim.devices.all())
 ```
 
 ### Threading

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -79,7 +79,9 @@ class Endpoint(object):
         Returns all objects from an endpoint.
 
         :arg int,optional limit: Overrides the max page size on
-            paginated returns.
+            paginated returns.  This defines the number of records that will
+            be returned with each query to the Netbox server.  The queries
+            will be made as you iterate through the result set.
         :arg int,optional offset: Overrides the offset on paginated returns.
 
         :Returns: A :py:class:`.RecordSet` object.
@@ -98,6 +100,9 @@ class Endpoint(object):
         If you want to iterate over the results multiple times then
         encapsulate them in a list like this:
         >>> devices = list(nb.dcim.devices.all())
+        
+        This will cause the entire result set
+        to be fetched from the server.
 
         """
         if limit == 0 and offset is not None:
@@ -190,7 +195,9 @@ class Endpoint(object):
         :arg str,optional \**kwargs: Any search argument the
             endpoint accepts can be added as a keyword arg.
         :arg int,optional limit: Overrides the max page size on
-            paginated returns.
+            paginated returns.  This defines the number of records that will
+            be returned with each query to the Netbox server.  The queries
+            will be made as you iterate through the result set.
         :arg int,optional offset: Overrides the offset on paginated returns.
 
         :Returns: A :py:class:`.RecordSet` object.
@@ -240,7 +247,8 @@ class Endpoint(object):
         >>>
 
         To have the ability to iterate over the results multiple times then
-        encapsulate them in a list.
+        encapsulate them in a list.  This will cause the entire result set
+        to be fetched from the server.
 
         >>> devices = list(nb.dcim.devices.filter(role='leaf-switch'))
         """

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -94,6 +94,11 @@ class Endpoint(object):
         test1-leaf2
         test1-leaf3
         >>>
+        
+        If you want to iterate over the results multiple times then
+        encapsulate them in a list like this:
+        >>> devices = list(nb.dcim.devices.all())
+
         """
         if limit == 0 and offset is not None:
             raise ValueError("offset requires a positive limit value")
@@ -233,6 +238,11 @@ class Endpoint(object):
         test1-a3-spine2
         test1-a3-leaf1
         >>>
+
+        To have the ability to iterate over the results multiple times then
+        encapsulate them in a list.
+
+        >>> devices = list(nb.dcim.devices.filter(role='leaf-switch'))
         """
 
         if args:

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -86,7 +86,7 @@ class Endpoint(object):
 
         :Examples:
 
-        >>> devices = nb.dcim.devices.all()
+        >>> devices = list(nb.dcim.devices.all())
         >>> for device in devices:
         ...     print(device.name)
         ...


### PR DESCRIPTION
Updating doco to reflect the need to encapsulate the result set in a list when calling the all() method of an endpoint.

See disscussion in netbox-community#450 and also sol1james#1


