### PR TITLE
Fix for limit without offset being ignored

### DIFF
--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -320,8 +320,9 @@ class Request(object):
         req = self._make_call(add_params=add_params)
         if isinstance(req, dict) and req.get("results") is not None:
             self.count = req["count"]
-            if self.offset is not None:
+            if self.limit or self.offset is not None:
                 # only yield requested page results if paginating
+                # or requesting a limited set
                 for i in req["results"]:
                     yield i
             elif self.threading:


### PR DESCRIPTION
If the limit kwarg is passed without an offset it will functionally be ignored and the entire result set will be returned.

Previously:
```
tenants = netbox_api.tenancy.tenants.all(limit=50)
print(f'Limit Size: {tenants.request.limit}')
print(f'Length of Iterable: {len(tenants)}')
...
Limit Size: 50
Length of Iterable: 5409
```

The simple fix was to provide only the results from netbox when limit or offset were provided. This fixes the output:

```
Limit Size: 50
Length of Iterable: 50
```