### PR TITLE
Enable available_ips for ip_ranges

### DIFF
--- a/pynetbox/models/ipam.py
+++ b/pynetbox/models/ipam.py
@@ -22,6 +22,42 @@ class IpAddresses(Record):
         return str(self.address)
 
 
+class IpRanges(Record):
+    def __str__(self):
+        return str(self.display)
+
+    @property
+    def available_ips(self):
+        """Represents the ``available-ips`` detail endpoint.
+
+        Returns a DetailEndpoint object that is the interface for
+        viewing and creating IP addresses inside an ip range .
+
+        :returns: :py:class:`.DetailEndpoint`
+
+        :Examples:
+
+        >>> ip_range = nb.ipam.ip_ranges.get(24)
+        >>> ip_range.available_ips.list()
+        [10.0.0.1/24, 10.0.0.2/24, 10.0.0.3/24, 10.0.0.4/24, 10.0.0.5/24, ...]
+
+        To create a single IP:
+
+        >>> ip_range = nb.ipam.ip_ranges.get(24)
+        >>> ip_range.available_ips.create()
+        10.0.0.1/24
+
+
+        To create multiple IPs:
+
+        >>> ip_range = nb.ipam.ip_ranges.get(24)
+        >>> create = ip_range.available_ips.create([{} for i in range(2)])
+        >>> create
+        [10.0.0.2/24, 10.0.0.3/24]
+        """
+        return DetailEndpoint(self, "available-ips", custom_return=IpAddresses)
+
+
 class Prefixes(Record):
     def __str__(self):
         return str(self.prefix)

--- a/tests/unit/test_detailendpoint.py
+++ b/tests/unit/test_detailendpoint.py
@@ -15,6 +15,7 @@ nb = pynetbox.api("http://localhost:8000")
 
 class DetailEndpointTestCase(unittest.TestCase):
     def test_detail_endpoint_create_single(self):
+        # Prefixes
         with patch(
             "pynetbox.core.query.Request._make_call",
             return_value={"id": 123, "prefix": "1.2.3.0/24"},
@@ -27,8 +28,22 @@ class DetailEndpointTestCase(unittest.TestCase):
         ):
             ip_obj = prefix_obj.available_ips.create()
             self.assertEqual(ip_obj.address, "1.2.3.1/24")
+        # IP Ranges
+        with patch(
+            "pynetbox.core.query.Request._make_call",
+            return_value={"id": 321, "display": "1.2.4.1-254/24"},
+        ):
+            ip_range_obj = nb.ipam.ip_ranges.get(321)
+            self.assertEqual(ip_range_obj.display, "1.2.4.1-254/24")
+        with patch(
+            "pynetbox.core.query.Request._make_call",
+            return_value={"address": "1.2.4.2/24"},
+        ):
+            ip_obj = ip_range_obj.available_ips.create()
+            self.assertEqual(ip_obj.address, "1.2.4.2/24")
 
     def test_detail_endpoint_create_list(self):
+        # Prefixes
         with patch(
             "pynetbox.core.query.Request._make_call",
             return_value={"id": 123, "prefix": "1.2.3.0/24"},
@@ -40,5 +55,19 @@ class DetailEndpointTestCase(unittest.TestCase):
             return_value=[{"address": "1.2.3.1/24"}, {"address": "1.2.3.2/24"}],
         ):
             ip_list = prefix_obj.available_ips.create([{} for _ in range(2)])
+            self.assertTrue(isinstance(ip_list, list))
+            self.assertEqual(len(ip_list), 2)
+        # IP Ranges
+        with patch(
+            "pynetbox.core.query.Request._make_call",
+            return_value={"id": 321, "display": "1.2.4.1-254/24"},
+        ):
+            ip_range_obj = nb.ipam.ip_ranges.get(321)
+            self.assertEqual(ip_range_obj.display, "1.2.4.1-254/24")
+        with patch(
+            "pynetbox.core.query.Request._make_call",
+            return_value=[{"address": "1.2.4.2/24"}, {"address": "1.2.4.3/24"}],
+        ):
+            ip_list = ip_range_obj.available_ips.create([{} for _ in range(2)])
             self.assertTrue(isinstance(ip_list, list))
             self.assertEqual(len(ip_list), 2)


### PR DESCRIPTION
Per the internal Netbox documentation the following endpoint is
available: /ipam/ip-ranges/{id}/available-ips/

pynetbox currently does not support this. This change adds the
available_ips method to the IpRanges class to enable this
functionality.