### PR TITLE
Fixes path for plugin names with underscores

### DIFF
--- a/pynetbox/core/app.py
+++ b/pynetbox/core/app.py
@@ -176,7 +176,7 @@ class PluginsApp(object):
         self.__dict__.update(d)
 
     def __getattr__(self, name):
-        return App(self.api, "plugins/{}".format(name.replace("_", "-")))
+        return App(self.api, f"plugins/{name}")
 
     def installed_plugins(self):
         """Returns raw response with installed plugins


### PR DESCRIPTION
For the plugin `netbox-secretstore` and `netbox-access-lists`, I'm unable to use the library because the code auto replaces the `_` with `-`. This causes issues because the path to the APIs require the use of `underscores`