### PR TITLE
Add link to mypy stubs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,7 @@ nb = pynetbox.api(
     threading=True,
 )
 ```
+
+### Testing
+
+Mypy stubs are available for pynetbox at the following repo and PRs are welcome: https://github.com/interdotlink/pynetbox-stubs


### PR DESCRIPTION
This PR adds a link to mypy stubs for pynetbox in the Readme.

This resolves issue #333 (for now, ideally the community will contribute and help the stubs files to grow).