### PR TITLE
Create get_or_raise endpoint

### DIFF
--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -173,6 +173,39 @@ class Endpoint:
             else:
                 raise e
 
+    def get_or_raise(self, *args, **kwargs):
+        r"""Queries the DetailsView of a given endpoint but raises an error if no object is returned
+        :arg int,optional key: id for the item to be
+            retrieved.
+
+        :arg str,optional \**kwargs: Accepts the same keyword args as
+            filter(). Any search argument the endpoint accepts can
+            be added as a keyword arg.
+
+        :returns: A single :py:class:`.Record` object
+
+        :raises ValueError: if kwarg search returns zero or more than one item
+
+        :Examples:
+
+        Referencing with a kwarg that only returns one value.
+
+        >>> nb.dcim.devices.get_or_raise(name='test1-a3-tor1b')
+        test1-a3-tor1b
+        >>>
+
+        Referencing with an id.
+
+        >>> nb.dcim.devices.get_or_raise(1)
+        test1-edge1
+        >>>
+        """
+
+        resp = self.get(*args, **kwargs)
+        if resp is None:
+            raise ValueError(f"{self.name} not found: {kwargs}")
+        return resp
+
     def filter(self, *args, **kwargs):
         r"""Queries the 'ListView' of a given endpoint.
 


### PR DESCRIPTION
Using the normal get endpoint on Pynetbox doesn't raise any error if no object is returned. This means that we need to constantly check on our side every time get is called to make sure that an object is returned. 
This aims at avoiding: 

```python
if not response:= nb.dcim.locations.get(id=1): 
    raise ValueError("location not found")
```

Using get_or_raise ensure that in the case of no object returned a ValueError is raised.

This way we can also use the python stubs mentioned [here](https://github.com/interdotlink/pynetbox-stubs/blob/main/pynetbox-stubs/_gen/circuits.pyi#L73 ) without having the tag Optional. 

Not that there is also an inconsistency between `get(myid)` and `get(id=myid)`: The former raises a Request error for unknown object, the latter one returns None.