### PR TITLE
Fixes: Enforce application/json content type

### DIFF
--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -163,7 +163,7 @@ class Request:
     def get_openapi(self):
         """Gets the OpenAPI Spec"""
         headers = {
-            "Content-Type": "application/json;",
+            "Content-Type": "application/json",
         }
         req = self.http_session.get(
             "{}docs/?format=openapi".format(self.normalize_url(self.base)),
@@ -185,7 +185,7 @@ class Request:
         present in the headers.
         """
         headers = {
-            "Content-Type": "application/json;",
+            "Content-Type": "application/json",
         }
         req = self.http_session.get(
             self.normalize_url(self.base),
@@ -227,7 +227,7 @@ class Request:
         :Returns: Dictionary as returned by NetBox.
         :Raises: RequestError if request is not successful.
         """
-        headers = {"Content-Type": "application/json;"}
+        headers = {"Content-Type": "application/json"}
         if self.token:
             headers["authorization"] = "Token {}".format(self.token)
         req = self.http_session.get(

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -248,7 +248,7 @@ class Request:
 
     def _make_call(self, verb="get", url_override=None, add_params=None, data=None):
         if verb in ("post", "put") or verb == "delete" and data:
-            headers = {"Content-Type": "application/json;"}
+            headers = {"Content-Type": "application/json"}
         else:
             headers = {"accept": "application/json;"}
 


### PR DESCRIPTION
With Version 3.3 the Content Type: application/json is enforced by netbox. https://github.com/netbox-community/netbox/commit/bfbf97aec9119539f7f42cf16f52d0ca8203ba60 / https://www.django-rest-framework.org/api-guide/parsers/

It takes long to find the Problem why i am getting a 403 Error just while Post requests.
I finally get it fixed by removing the ";" in all '"Content-Type": "application/json;"'.
Also in all API examples its always called without the ending ";". [docs/integrations/rest-api.md](https://github.com/netbox-community/netbox/blob/21b9732f061b7e91fa77c10da66bd098510354fc/docs/integrations/rest-api.md) / https://github.com/netbox-community/netbox/blob/d2fe59ae8f9c34c1f8a7d51c0d113348d7bed937/netbox/utilities/api.py#L52

Hope this is request is okay?