### PR TITLE
Remove pre-NetBox 3.3 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,11 @@ To begin, import pynetbox and instantiate the API.
 import pynetbox
 nb = pynetbox.api(
     'http://localhost:8000',
-    private_key_file='/path/to/private-key.pem',
     token='d6f4e314a5b5fefd164995169f28ae32d987704f'
 )
 ```
 
-The first argument the .api() method takes is the NetBox URL. There are a handful of named arguments you can provide, but in most cases none are required to simply pull data. In order to write, the `token` argument should to be provided. To decrypt information from the `secrets` endpoint either the `private_key_file` or `private_key` argument needs to be provided.
+The first argument the .api() method takes is the NetBox URL. There are a handful of named arguments you can provide, but in most cases none are required to simply pull data. In order to write, the `token` argument should to be provided.
 
 
 ## Queries

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -16,7 +16,6 @@ To set a custom header on all requests. These headers are automatically merged w
 >>> session.headers = {"mycustomheader": "test"}
 >>> nb = pynetbox.api(
 ...     'http://localhost:8000',
-...     private_key_file='/path/to/private-key.pem',
 ...     token='d6f4e314a5b5fefd164995169f28ae32d987704f'
 ... )
 >>> nb.http_session = session
@@ -35,7 +34,6 @@ To disable SSL verification. See `the docs <https://requests.readthedocs.io/en/s
 >>> session.verify = False
 >>> nb = pynetbox.api(
 ...     'http://localhost:8000',
-...     private_key_file='/path/to/private-key.pem',
 ...     token='d6f4e314a5b5fefd164995169f28ae32d987704f'
 ... )
 >>> nb.http_session = session
@@ -68,7 +66,6 @@ Setting timeouts requires the use of Adapters.
 
     nb = pynetbox.api(
         'http://localhost:8000',
-        private_key_file='/path/to/private-key.pem',
         token='d6f4e314a5b5fefd164995169f28ae32d987704f'
     )
     nb.http_session = session

--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -50,13 +50,8 @@ class Api:
     :param str url: The base URL to the instance of NetBox you
         wish to connect to.
     :param str token: Your NetBox token.
-    :param str,optional private_key_file: The path to your private
-        key file. (Usable only on NetBox 2.11 and older)
-    :param str,optional private_key: Your private key. (Usable only on NetBox 2.11 and older)
     :param bool,optional threading: Set to True to use threading in ``.all()``
         and ``.filter()`` requests.
-    :raises ValueError: If *private_key* and *private_key_file* are both
-        specified.
     :raises AttributeError: If app doesn't exist.
     :Examples:
 
@@ -73,28 +68,14 @@ class Api:
         self,
         url,
         token=None,
-        private_key=None,
-        private_key_file=None,
         threading=False,
     ):
-        if private_key and private_key_file:
-            raise ValueError(
-                '"private_key" and "private_key_file" cannot be used together.'
-            )
         base_url = "{}/api".format(url if url[-1] != "/" else url[:-1])
         self.token = token
-        self.private_key = private_key
-        self.private_key_file = private_key_file
         self.base_url = base_url
         self.session_key = None
         self.http_session = requests.Session()
         self.threading = threading
-
-        if self.private_key_file:
-            with open(self.private_key_file, "r") as kf:
-                private_key = kf.read()
-                self.private_key = private_key
-
         self.dcim = App(self, "dcim")
         self.ipam = App(self, "ipam")
         self.circuits = App(self, "circuits")

--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -30,7 +30,6 @@ class Api:
         * dcim
         * ipam
         * circuits
-        * secrets (on NetBox 2.11 and older)
         * tenancy
         * extras
         * virtualization
@@ -73,13 +72,11 @@ class Api:
         base_url = "{}/api".format(url if url[-1] != "/" else url[:-1])
         self.token = token
         self.base_url = base_url
-        self.session_key = None
         self.http_session = requests.Session()
         self.threading = threading
         self.dcim = App(self, "dcim")
         self.ipam = App(self, "ipam")
         self.circuits = App(self, "circuits")
-        self.secrets = App(self, "secrets")
         self.tenancy = App(self, "tenancy")
         self.extras = App(self, "extras")
         self.virtualization = App(self, "virtualization")

--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -134,8 +134,6 @@ class Api:
     def status(self):
         """Gets the status information from NetBox.
 
-        Available in NetBox 2.10.0 or newer.
-
         :Returns: Dictionary as returned by NetBox.
         :Raises: :py:class:`.RequestError` if the request is not successful.
         :Example:
@@ -169,8 +167,6 @@ class Api:
     def create_token(self, username, password):
         """Creates an API token using a valid NetBox username and password.
         Saves the created token automatically in the API object.
-
-        Requires NetBox 3.0.0 or newer.
 
         :Returns: The token as a ``Record`` object.
         :Raises: :py:class:`.RequestError` if the request is not successful.

--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -33,8 +33,8 @@ class Api:
         * tenancy
         * extras
         * virtualization
-        * users (since NetBox 2.9)
-        * wireless (since NetBox 3.1)
+        * users
+        * wireless
 
     Calling any of these attributes will return
     :py:class:`.App` which exposes endpoints as attributes.

--- a/pynetbox/core/app.py
+++ b/pynetbox/core/app.py
@@ -87,33 +87,6 @@ class App:
 
         return self._choices
 
-    def custom_choices(self):
-        """Returns _custom_field_choices response from app
-
-        .. note::
-
-            This method only works with NetBox version 2.9.x or older. NetBox
-            2.10.0 introduced the ``/extras/custom-fields/`` endpoint that can
-            be used f.ex. like ``nb.extras.custom_fields.all()``.
-
-        :Returns: Raw response from NetBox's _custom_field_choices endpoint.
-        :Raises: :py:class:`.RequestError` if called for an invalid endpoint.
-        :Example:
-
-        >>> nb.extras.custom_choices()
-        {'Testfield1': {'Testvalue2': 2, 'Testvalue1': 1},
-         'Testfield2': {'Othervalue2': 4, 'Othervalue1': 3}}
-        """
-        custom_field_choices = Request(
-            base="{}/{}/_custom_field_choices/".format(
-                self.api.base_url,
-                self.name,
-            ),
-            token=self.api.token,
-            http_session=self.api.http_session,
-        ).get()
-        return custom_field_choices
-
     def config(self):
         """Returns config response from app
 

--- a/pynetbox/core/app.py
+++ b/pynetbox/core/app.py
@@ -39,7 +39,6 @@ class App:
     def __init__(self, api, name):
         self.api = api
         self.name = name
-        self._choices = None
         self._setmodel()
 
     models = {
@@ -56,7 +55,7 @@ class App:
         self.model = App.models[self.name] if self.name in App.models else None
 
     def __getstate__(self):
-        return {"api": self.api, "name": self.name, "_choices": self._choices}
+        return {"api": self.api, "name": self.name}
 
     def __setstate__(self, d):
         self.__dict__.update(d)
@@ -64,28 +63,6 @@ class App:
 
     def __getattr__(self, name):
         return Endpoint(self.api, self, name, model=self.model)
-
-    def choices(self):
-        """Returns _choices response from App
-
-        .. note::
-
-            This method is deprecated and only works with NetBox version 2.7.x
-            or older. The ``choices()`` method in :py:class:`.Endpoint` is
-            compatible with all NetBox versions.
-
-        :Returns: Raw response from NetBox's _choices endpoint.
-        """
-        if self._choices:
-            return self._choices
-
-        self._choices = Request(
-            base="{}/{}/_choices/".format(self.api.base_url, self.name),
-            token=self.api.token,
-            http_session=self.api.http_session,
-        ).get()
-
-        return self._choices
 
     def config(self):
         """Returns config response from app

--- a/pynetbox/core/app.py
+++ b/pynetbox/core/app.py
@@ -63,20 +63,7 @@ class App:
         self._setmodel()
 
     def __getattr__(self, name):
-        if name == "secrets":
-            self._set_session_key()
         return Endpoint(self.api, self, name, model=self.model)
-
-    def _set_session_key(self):
-        if getattr(self.api, "session_key"):
-            return
-        if self.api.token and self.api.private_key:
-            self.api.session_key = Request(
-                base=self.api.base_url,
-                token=self.api.token,
-                private_key=self.api.private_key,
-                http_session=self.api.http_session,
-            ).get_session_key()
 
     def choices(self):
         """Returns _choices response from App
@@ -95,7 +82,6 @@ class App:
         self._choices = Request(
             base="{}/{}/_choices/".format(self.api.base_url, self.name),
             token=self.api.token,
-            private_key=self.api.private_key,
             http_session=self.api.http_session,
         ).get()
 
@@ -124,7 +110,6 @@ class App:
                 self.name,
             ),
             token=self.api.token,
-            private_key=self.api.private_key,
             http_session=self.api.http_session,
         ).get()
         return custom_field_choices
@@ -151,7 +136,6 @@ class App:
                 self.name,
             ),
             token=self.api.token,
-            private_key=self.api.private_key,
             http_session=self.api.http_session,
         ).get()
         return config
@@ -198,7 +182,6 @@ class PluginsApp:
                 self.api.base_url,
             ),
             token=self.api.token,
-            private_key=self.api.private_key,
             http_session=self.api.http_session,
         ).get()
         return installed_plugins

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -46,7 +46,6 @@ class Endpoint:
         self.api = api
         self.base_url = api.base_url
         self.token = api.token
-        self.session_key = api.session_key
         self.url = "{base_url}/{app}/{endpoint}".format(
             base_url=self.base_url,
             app=app.name,
@@ -100,7 +99,6 @@ class Endpoint:
         req = Request(
             base="{}/".format(self.url),
             token=self.token,
-            session_key=self.session_key,
             http_session=self.api.http_session,
             threading=self.api.threading,
             limit=limit,
@@ -162,7 +160,6 @@ class Endpoint:
             key=key,
             base=self.url,
             token=self.token,
-            session_key=self.session_key,
             http_session=self.api.http_session,
         )
         try:
@@ -251,7 +248,6 @@ class Endpoint:
             filters=kwargs,
             base=self.url,
             token=self.token,
-            session_key=self.session_key,
             http_session=self.api.http_session,
             threading=self.api.threading,
             limit=limit,
@@ -313,7 +309,6 @@ class Endpoint:
         req = Request(
             base=self.url,
             token=self.token,
-            session_key=self.session_key,
             http_session=self.api.http_session,
         ).post(args[0] if args else kwargs)
 
@@ -380,7 +375,6 @@ class Endpoint:
         req = Request(
             base=self.url,
             token=self.token,
-            session_key=self.session_key,
             http_session=self.api.http_session,
         ).patch(series)
 
@@ -445,7 +439,6 @@ class Endpoint:
         req = Request(
             base=self.url,
             token=self.token,
-            session_key=self.session_key,
             http_session=self.api.http_session,
         )
         return True if req.delete(data=[{"id": i} for i in cleaned_ids]) else False
@@ -485,7 +478,6 @@ class Endpoint:
         req = Request(
             base=self.url,
             token=self.api.token,
-            private_key=self.api.private_key,
             http_session=self.api.http_session,
         ).options()
         try:
@@ -545,7 +537,6 @@ class Endpoint:
             filters=kwargs,
             base=self.url,
             token=self.token,
-            session_key=self.session_key,
             http_session=self.api.http_session,
         )
 
@@ -566,7 +557,6 @@ class DetailEndpoint:
         self.request_kwargs = dict(
             base=self.url,
             token=parent_obj.api.token,
-            session_key=parent_obj.api.session_key,
             http_session=parent_obj.api.http_session,
         )
 

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -454,7 +454,7 @@ class Endpoint:
 
         :Returns: Dict containing the available choices.
 
-        :Example (from NetBox 2.8.x):
+        :Example:
 
         >>> from pprint import pprint
         >>> pprint(nb.ipam.ip_addresses.choices())
@@ -469,7 +469,8 @@ class Endpoint:
          'status': [{'display_name': 'Active', 'value': 'active'},
                     {'display_name': 'Reserved', 'value': 'reserved'},
                     {'display_name': 'Deprecated', 'value': 'deprecated'},
-                    {'display_name': 'DHCP', 'value': 'dhcp'}]}
+                    {'display_name': 'DHCP', 'value': 'dhcp'},
+                    {'display_name': 'SLAAC', 'value': 'slaac'}]}
         >>>
         """
         if self._choices:

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 import concurrent.futures as cf
 import json
-from urllib.parse import urlencode
 
 
 def calc_pages(limit, count):

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -71,8 +71,7 @@ class AllocationError(Exception):
     """Allocation Exception
 
     Used with available-ips/available-prefixes when there is no
-    room for allocation and NetBox returns 204 No Content (before
-    NetBox 3.1.1) or 409 Conflict (since NetBox 3.1.1+).
+    room for allocation and NetBox returns 409 Conflict.
     """
 
     def __init__(self, req):
@@ -233,7 +232,7 @@ class Request:
             url_override or self.url, headers=headers, params=params, json=data
         )
 
-        if req.status_code in [204, 409] and verb == "post":
+        if req.status_code == 409 and verb == "post":
             raise AllocationError(req)
         if verb == "delete":
             if req.ok:
@@ -350,7 +349,7 @@ class Request:
         :param data: (dict) Contains a dict that will be turned into a
             json object and sent to the API.
         :raises: RequestError if req.ok returns false.
-        :raises: AllocationError if req.status_code is 204 (No Content)
+        :raises: AllocationError if req.status_code is 409 (Conflict)
             as with available-ips and available-prefixes when there is
             no room for the requested allocation.
         :raises: ContentError if response is not json.

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -441,7 +441,6 @@ class Record:
             req = Request(
                 base=self.url,
                 token=self.api.token,
-                session_key=self.api.session_key,
                 http_session=self.api.http_session,
             )
             self._parse_values(next(req.get()))
@@ -554,7 +553,6 @@ class Record:
                 key=self.id,
                 base=self.endpoint.url,
                 token=self.api.token,
-                session_key=self.api.session_key,
                 http_session=self.api.http_session,
             )
             if req.patch(updates):
@@ -601,7 +599,6 @@ class Record:
             key=self.id,
             base=self.endpoint.url,
             token=self.api.token,
-            session_key=self.api.session_key,
             http_session=self.api.http_session,
         )
         return True if req.delete() else False

--- a/pynetbox/models/dcim.py
+++ b/pynetbox/models/dcim.py
@@ -57,7 +57,6 @@ class TraceableRecord(Record):
             key=str(self.id) + "/trace",
             base=self.endpoint.url,
             token=self.api.token,
-            session_key=self.api.session_key,
             http_session=self.api.http_session,
         ).get()
 

--- a/pynetbox/models/ipam.py
+++ b/pynetbox/models/ipam.py
@@ -148,8 +148,6 @@ class VlanGroups(Record):
         Returns a DetailEndpoint object that is the interface for
         viewing and creating VLANs inside a VLAN group.
 
-        Available since NetBox 3.2.0.
-
         :returns: :py:class:`.DetailEndpoint`
 
         :Examples:

--- a/tests/fixtures/api/get_session_key.json
+++ b/tests/fixtures/api/get_session_key.json
@@ -1,3 +1,0 @@
-{
-    "session_key": "ansodicnaoiwenafoi="
-}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,5 @@
 import os
 
-from packaging import version
 import subprocess as subp
 import time
 import yaml

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,6 @@ host = "http://localhost:8000"
 
 def_kwargs = {
     "token": "abc123",
-    "private_key_file": "tests/fixtures/api/get_session_key.json",
 }
 
 # Keys are app names, values are arbitrarily selected endpoints
@@ -26,7 +25,7 @@ endpoints = {
 class ApiTestCase(unittest.TestCase):
     @patch(
         "requests.sessions.Session.post",
-        return_value=Response(fixture="api/get_session_key.json"),
+        return_value=Response(),
     )
     def test_get(self, *_):
         api = pynetbox.api(host, **def_kwargs)
@@ -34,7 +33,7 @@ class ApiTestCase(unittest.TestCase):
 
     @patch(
         "requests.sessions.Session.post",
-        return_value=Response(fixture="api/get_session_key.json"),
+        return_value=Response(),
     )
     def test_sanitize_url(self, *_):
         api = pynetbox.api("http://localhost:8000/", **def_kwargs)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,21 +11,6 @@ def_kwargs = {
 }
 
 
-class AppCustomChoicesTestCase(unittest.TestCase):
-    @patch(
-        "pynetbox.core.query.Request.get",
-        return_value={
-            "Testfield1": {"TF1_1": 1, "TF1_2": 2},
-            "Testfield2": {"TF2_1": 3, "TF2_2": 4},
-        },
-    )
-    def test_custom_choices(self, *_):
-        api = pynetbox.api(host, **def_kwargs)
-        choices = api.extras.custom_choices()
-        self.assertEqual(len(choices), 2)
-        self.assertEqual(sorted(choices.keys()), ["Testfield1", "Testfield2"])
-
-
 class AppConfigTestCase(unittest.TestCase):
     @patch(
         "pynetbox.core.query.Request.get",
@@ -52,20 +37,7 @@ class AppConfigTestCase(unittest.TestCase):
         )
 
 
-class PluginAppCustomChoicesTestCase(unittest.TestCase):
-    @patch(
-        "pynetbox.core.query.Request.get",
-        return_value={
-            "Testfield1": {"TF1_1": 1, "TF1_2": 2},
-            "Testfield2": {"TF2_1": 3, "TF2_2": 4},
-        },
-    )
-    def test_custom_choices(self, *_):
-        api = pynetbox.api(host, **def_kwargs)
-        choices = api.plugins.test_plugin.custom_choices()
-        self.assertEqual(len(choices), 2)
-        self.assertEqual(sorted(choices.keys()), ["Testfield1", "Testfield2"])
-
+class PluginAppTestCase(unittest.TestCase):
     @patch(
         "pynetbox.core.query.Request.get",
         return_value=[

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -162,32 +162,7 @@ class RecordTestCase(unittest.TestCase):
         test = Record(test_values, None, None)
         self.assertEqual(dict(test), test_values)
 
-    def test_choices_idempotence_prev27(self):
-        test_values = {
-            "id": 123,
-            "choices_test": {
-                "value": 1,
-                "label": "test",
-            },
-        }
-        test = Record(test_values, None, None)
-        test.choices_test = 1
-        self.assertFalse(test._diff())
-
-    def test_choices_idempotence_v27(self):
-        test_values = {
-            "id": 123,
-            "choices_test": {
-                "value": "test",
-                "label": "test",
-                "id": 1,
-            },
-        }
-        test = Record(test_values, None, None)
-        test.choices_test = "test"
-        self.assertFalse(test._diff())
-
-    def test_choices_idempotence_v28(self):
+    def test_choices_idempotence(self):
         test_values = {
             "id": 123,
             "choices_test": {

--- a/tests/util.py
+++ b/tests/util.py
@@ -8,6 +8,8 @@ class Response:
         self.ok = ok
 
     def load_fixture(self, path):
+        if not path:
+            return "{}"
         with open("tests/fixtures/{}".format(path), "r") as f:
             return f.read()
 


### PR DESCRIPTION
Removes references to `secrets` app (removed in NetBox 3.0) and the related private key and session key references since `pynetbox` 7.x is now for NetBox 3.3(+) only.

Also removes
- `App.choices()` (only worked with NetBox 2.7.x and older)
- `App.custom_choices()` (only worked with NetBox 2.9.x and older)
