### PR TITLE
Fix project URL in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name="pynetbox",
     description="NetBox API client library",
-    url="https://github.com/netbox-community/netbox",
+    url="https://github.com/netbox-community/pynetbox",
     author="Zach Moody",
     author_email="zmoody@do.co",
     license="Apache2",


### PR DESCRIPTION
`pynetbox` is not the same piece of software as `netbox`.

When I followed the link on the `pypi` homepage to check out this packages source code, I was redirected to the `netbox` repository and assumed that `pynetbox` was a part of `netbox`, in the sense that this package was something like a build artifact from the `netbox` package. This assumption turned out to be wrong. The thought that it was just in a separate project of the same organization did not occur to me, what remained for a few minutes was mainly confusion. I had to conduct a full-text-search in the netbox repository to find out where `pynetbox` lives. This indirection is a little suboptimal.

I thus think it is much more reasonable to link to the repository of the python package itself.