### PR TITLE
Fix __str__ on Record to always return a string

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -323,7 +323,7 @@ class Record:
         return dict(self)[k]
 
     def __str__(self):
-        return (
+        return str(
             getattr(self, "name", None)
             or getattr(self, "label", None)
             or getattr(self, "display", None)


### PR DESCRIPTION
# Summary

On certain edge cases, it is possible for the `__str__` method of a Record object to return something that is not of type `str`, which raises an Exception: `TypeError: __str__ returned non-string (type Record)`

# Steps to reproduce

```python
import pynetbox
nb = pynetbox.api("http://localhost:8080", token="0123456789abcdef0123456789abcdef01234567")

# create test platform
platform = nb.dcim.platforms.create(
    name="test platform",
    slug="test-platform",
    napalm_args={
        "anything": {
            "name": {
                "attr1": "value1",
                "attr2": "value2",
            }
        },
    }
)
```

This is one of the ways this bug will be triggered. It can happen on any object can hold arbitrary JSON data in a field that is not explicitly mapped to a `JsonField` class in pynetbox (for example a `config_context` on `dcim.devices` will not trigger the bug)

# Description

When a generic Record is generated from data returned by the API, each field is dynamically mapped deeply to find candidate Records with other well-known objects types. However, some netbox objects can hold arbitrary JSON, and if that JSON (dictionary) is not explicitly mapped to a `JsonField`, it will be interpreted as a Record object. Printing the Record will hence look for the keys that should represent it (`name`, `label`, `display`) and otherwise return an empty string. Given that these fields can be set to arbitrary values, the data can be of any type, which breaks the implicit assumption that it should be a `str`.

# Fix

The PR simply add a call to `str` on the result that should be returned.
