### PR TITLE
Fix unused `PowerPorts` model (#535)

### DIFF
--- a/pynetbox/models/mapper.py
+++ b/pynetbox/models/mapper.py
@@ -59,7 +59,7 @@ CONTENT_TYPE_MAPPER = {
     "dcim.poweroutlet": PowerOutlets,
     "dcim.poweroutlettemplate": None,
     "dcim.powerpanel": None,
-    "dcim.powerport": ConsolePorts,
+    "dcim.powerport": PowerPorts,
     "dcim.powerporttemplate": None,
     "dcim.rack": Racks,
     "dcim.rackreservation": RackReservations,


### PR DESCRIPTION
Updated models/mapper.py: set `PowerPorts` for "dcim.powerport" in the map-dict.