### PR TITLE
Fix string concatenation in enpoint.py (#538)

### DIFF
--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -458,7 +458,8 @@ class Endpoint:
         series = []
         if not isinstance(objects, list):
             raise ValueError(
-                "Objects passed must be list[dict|Record] - was " + type(objects)
+                "Objects passed must be list[dict|Record] - was {}".format(
+                    type(objects))
             )
         for o in objects:
             if isinstance(o, Record):
@@ -472,7 +473,8 @@ class Endpoint:
                 series.append(o)
             else:
                 raise ValueError(
-                    "Object passed must be dict|Record - was " + type(objects)
+                    "Object passed must be dict|Record - was {}".format(
+                        type(objects))
                 )
         req = Request(
             base=self.url,


### PR DESCRIPTION
Update pynetbox/core/endpoint.py: add using of `.format()` instead of string concatenation.