### PR TITLE
Add `AsnRanges.available_asns` (for NetBox 3.5+)

### DIFF
--- a/docs/IPAM.rst
+++ b/docs/IPAM.rst
@@ -1,6 +1,9 @@
 IPAM
 ========
 
+.. autoclass:: pynetbox.models.ipam.AsnRanges
+  :members:
+
 .. autoclass:: pynetbox.models.ipam.Prefixes
   :members:
 

--- a/pynetbox/models/ipam.py
+++ b/pynetbox/models/ipam.py
@@ -17,6 +17,49 @@ from pynetbox.core.response import Record
 from pynetbox.core.endpoint import DetailEndpoint
 
 
+class Asns(Record):
+    def __str__(self):
+        return super().__str__() or str(self.asn)
+
+
+class AsnRanges(Record):
+    def __str__(self):
+        return str(self.display)
+
+    @property
+    def available_asns(self):
+        """Represents the ``available-asns`` detail endpoint.
+
+        Returns a DetailEndpoint object that is the interface for
+        viewing and creating ASNs inside an ASN range.
+
+        :returns: :py:class:`.DetailEndpoint`
+
+        :Examples:
+
+        >>> asn_range = nb.ipam.asn_ranges.get(5)
+        >>> asn_range
+        TestRange (65510-65512)
+        >>> asn_range.available_asns.list()
+        [65510, 65511, 65512]
+
+        To create a single ASN:
+
+        >>> asn_range = nb.ipam.asn_ranges.get(5)
+        >>> new_asn = asn_range.available_asns.create()
+        >>> new_asn
+        AS65510
+
+        To create multiple ASNs:
+
+        >>> asn_range = nb.ipam.asn_ranges.get(5)
+        >>> asns = asn_range.available_asns.create([{} for _ in range(2)])
+        >>> asns
+        [AS65510, AS65511]
+        """
+        return DetailEndpoint(self, "available-asns", custom_return=Asns)
+
+
 class IpAddresses(Record):
     def __str__(self):
         return str(self.address)


### PR DESCRIPTION
Example:

```
>>> asn_range = nb.ipam.asn_ranges.get(1)
>>> asn_range
TestRange (65510-65512)
>>> pprint.pprint(dict(asn_range))
{'created': '2023-04-16T10:59:57.566139+03:00',
 'custom_fields': {},
 'description': '',
 'display': 'TestRange (65510-65512)',
 'end': 65512,
 'id': 1,
 'last_updated': '2023-04-16T11:13:15.835726+03:00',
 'name': 'TestRange',
 'rir': {'display': 'RFC1918',
         'id': 1,
         'name': 'RFC1918',
         'slug': 'rfc1918',
         'url': 'http://netbox-future.lein.io/api/ipam/rirs/1/'},
 'slug': 'testrange',
 'start': 65510,
 'tags': [],
 'tenant': None,
 'url': 'http://netbox-future.lein.io/api/ipam/asn-ranges/1/'}
>>> asn_range.available_asns
<pynetbox.core.endpoint.DetailEndpoint object at 0x7f0224cc9a58>
>>> asn_range.available_asns.list()
[65510, 65511, 65512]
>>>
```