### PR TITLE
replace None with 'null' in query parameters

### DIFF
--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -285,8 +285,9 @@ class Endpoint:
         offset = kwargs.pop("offset") if "offset" in kwargs else None
         if limit == 0 and offset is not None:
             raise ValueError("offset requires a positive limit value")
+        filters = {x: y if y is not None else "null" for x, y in kwargs.items()}
         req = Request(
-            filters=kwargs,
+            filters=filters,
             base=self.url,
             token=self.token,
             http_session=self.api.http_session,

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -24,6 +24,14 @@ class EndPointTestCase(unittest.TestCase):
         with self.assertRaises(ValueError) as _:
             test_obj.filter(offset=1)
 
+    def test_filter_replace_none_with_null(self):
+        api = Mock(base_url="http://localhost:8000/api")
+        app = Mock(name="test")
+        test_obj = Endpoint(api, app, "test")
+        test = test_obj.filter(name=None, id=0)
+
+        self.assertEqual(test.request.filters, {"name": "null", "id": 0})
+
     def test_all_invalid_pagination_args(self):
 
         api = Mock(base_url="http://localhost:8000/api")


### PR DESCRIPTION
Requests skips parameters that are None.
Map 'null' string to None python type for a more native coding

eg: `nb.dcim.interfaces.filter(mac_address__n=None)`