### PR TITLE
Update OpenAPI endpoint for 3.5

### DIFF
--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -153,10 +153,10 @@ class Request:
     def get_openapi(self):
         """Gets the OpenAPI Spec"""
         headers = {
-            "Content-Type": "application/json;",
+            "Accept": "application/json",
         }
         req = self.http_session.get(
-            "{}docs/?format=openapi".format(self.normalize_url(self.base)),
+            "{}schema".format(self.normalize_url(self.base)),
             headers=headers,
         )
         if req.ok:


### PR DESCRIPTION
This breaks compatibility for older versions of NetBox.

If compatibility is desired, we can try the v3.5 endpoint first then attempt the older endpoint.