### PR TITLE
Fix permissions contraints handling in case of list of dicts (fixes #465)

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -413,6 +413,9 @@ class Record:
                 if len(v) and isinstance(v[0], dict) and "object_type" in v[0]:
                     v = [generic_list_parser(k, i) for i in v]
                     to_cache = list(v)
+                elif k == "constraints":
+                    # Permissions constraints can be either dict or list
+                    to_cache = copy.deepcopy(v)
                 else:
                     v = [list_parser(k, i) for i in v]
                     to_cache = list(v)

--- a/tests/fixtures/users/permission.json
+++ b/tests/fixtures/users/permission.json
@@ -5,5 +5,13 @@
         {
             "username": "user1"
         }
+    ],
+    "constraints": [
+        {
+            "status": "active"
+        },
+        {
+            "region__name": "Europe"
+        }
     ]
 }

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -110,6 +110,7 @@ class PermissionsTestCase(Generic.Tests):
     )
     def test_constraints(self, _):
         permission = nb.permissions.get(1)
+        self.assertTrue(isinstance(permission.constraints, list))
         self.assertTrue(isinstance(permission.constraints[0], dict))
 
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -110,8 +110,8 @@ class PermissionsTestCase(Generic.Tests):
     )
     def test_constraints(self, _):
         permission = nb.permissions.get(1)
-        self.assertTrue(isinstance(permission.constraints, list))
-        self.assertTrue(isinstance(permission.constraints[0], dict))
+        self.assertIsInstance(permission.constraints, list)
+        self.assertIsInstance(permission.constraints[0], dict)
 
 
 class UnknownModelTestCase(unittest.TestCase):

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -104,6 +104,14 @@ class PermissionsTestCase(Generic.Tests):
         user = permission.users[0]
         self.assertEqual(str(user), "user1")
 
+    @patch(
+        "requests.sessions.Session.get",
+        return_value=Response(fixture="users/permission.json"),
+    )
+    def test_constraints(self, _):
+        permission = nb.permissions.get(1)
+        self.assertTrue(isinstance(permission.constraints[0], dict))
+
 
 class UnknownModelTestCase(unittest.TestCase):
     """This test validates that an unknown model is returned as Record object


### PR DESCRIPTION
Fixes #465 

Before this fix:

```
>>> p = netbox.users.permissions.get(name="ViewSites")
>>> p.constraints
[{'status': 'active'}, {'region__name': 'Europe'}]
>>> type(p.constraints[0])
<class 'pynetbox.core.response.Record'>
>>>
```

After the fix:

```
>>> p = netbox.users.permissions.get(name="ViewSites")
>>> p.constraints
[{'status': 'active'}, {'region__name': 'Europe'}]
>>> type(p.constraints[0])
<class 'dict'>
>>>
```
