### PR TITLE
Get faster response for count() method

### DIFF
--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -409,5 +409,5 @@ class Request:
         """
 
         if not hasattr(self, "count"):
-            self.count = self._make_call(add_params={"limit": 1})["count"]
+            self.count = self._make_call(add_params={"limit": 1, "brief": 1})["count"]
         return self.count


### PR DESCRIPTION
By using `brief=1` parameter in the get_count() method, we can reliably get a much faster response.

As an example, without the parameter, running 100 iterations of these count action to my cloud NetBox instance:
nb.dcim.cables.count() : average duration 0.1 sec 
nb.ipam.ip_addresses.count() : average duration 0.47 sec

By adding `brief=1` :
nb.dcim.cables.count() : average duration 0.075 sec
nb.ipam.ip_addresses.count() : average duration 0.343 sec 