### PR TITLE
Add Python 3.11 in tests

### DIFF
--- a/.github/workflows/py3.yml
+++ b/.github/workflows/py3.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
         netbox: ["3.3", "3.4", "3.5"]
 
     steps:


### PR DESCRIPTION
My suggestion is to have all currently supported Python versions in the test workflows.

https://devguide.python.org/versions/
