### PR TITLE
core/endpoint: Get choices from PUT if POST missing

### DIFF
--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -587,9 +587,10 @@ class Endpoint:
             token=self.api.token,
             http_session=self.api.http_session,
         ).options()
-        try:
-            post_data = req["actions"]["POST"]
-        except KeyError:
+
+        actions = req.get("actions", {})
+        post_data = actions.get("POST") or actions.get("PUT")
+        if post_data is None:
             raise ValueError(
                 "Unexpected format in the OPTIONS response at {}".format(self.url)
             )

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -60,6 +60,59 @@ class EndPointTestCase(unittest.TestCase):
             self.assertEqual(choices["letter"][1]["display_name"], "B")
             self.assertEqual(choices["letter"][1]["value"], 2)
 
+    def test_choices_put(self):
+        with patch("pynetbox.core.query.Request.options", return_value=Mock()) as mock:
+            api = Mock(base_url="http://localhost:8000/api")
+            app = Mock(name="test")
+            mock.return_value = {
+                "actions": {
+                    "PUT": {
+                        "letter": {
+                            "choices": [
+                                {"display_name": "A", "value": 1},
+                                {"display_name": "B", "value": 2},
+                                {"display_name": "C", "value": 3},
+                            ]
+                        }
+                    }
+                }
+            }
+            test_obj = Endpoint(api, app, "test")
+            choices = test_obj.choices()
+            self.assertEqual(choices["letter"][0]["display_name"], "A")
+            self.assertEqual(choices["letter"][0]["value"], 1)
+
+    def test_choices_precedence(self):
+        with patch("pynetbox.core.query.Request.options", return_value=Mock()) as mock:
+            api = Mock(base_url="http://localhost:8000/api")
+            app = Mock(name="test")
+            mock.return_value = {
+                "actions": {
+                    "POST": {
+                        "letter": {
+                            "choices": [
+                                {"display_name": "A", "value": 1},
+                                {"display_name": "B", "value": 2},
+                                {"display_name": "C", "value": 3},
+                            ]
+                        }
+                    },
+                    "PUT": {
+                        "letter": {
+                            "choices": [
+                                {"display_name": "D", "value": 4},
+                                {"display_name": "E", "value": 5},
+                                {"display_name": "F", "value": 6},
+                            ]
+                        }
+                    },
+                }
+            }
+            test_obj = Endpoint(api, app, "test")
+            choices = test_obj.choices()
+            self.assertEqual(choices["letter"][2]["display_name"], "C")
+            self.assertEqual(choices["letter"][2]["value"], 3)
+
     def test_get_with_filter(self):
         with patch(
             "pynetbox.core.query.Request._make_call", return_value=Mock()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to pynetbox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #591

<!--
    Please include a summary of the proposed changes below.
-->

If the API token is not allowed to POST on a particular endpoint, choices won't be returned in `.actions.POST`, but we can still get them in `.actions.PUT`.

This commit falls back to getting choices from `.actions.PUT` instead of raising an exception when `.actions.POST` is missing.