### PR TITLE
Add `vpn` app for NetBox 3.7 compatibility

### DIFF
--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -27,14 +27,15 @@ class Api:
     you can specify which app and endpoint you wish to interact with.
 
     Valid attributes currently are:
+        * circuits
         * core (NetBox 3.5+)
         * dcim
-        * ipam
-        * circuits
-        * tenancy
         * extras
-        * virtualization
+        * ipam
+        * tenancy
         * users
+        * virtualization
+        * vpn (NetBox 3.7+)
         * wireless
 
     Calling any of these attributes will return
@@ -75,14 +76,15 @@ class Api:
         self.base_url = base_url
         self.http_session = requests.Session()
         self.threading = threading
+        self.circuits = App(self, "circuits")
         self.core = App(self, "core")
         self.dcim = App(self, "dcim")
-        self.ipam = App(self, "ipam")
-        self.circuits = App(self, "circuits")
-        self.tenancy = App(self, "tenancy")
         self.extras = App(self, "extras")
-        self.virtualization = App(self, "virtualization")
+        self.ipam = App(self, "ipam")
+        self.tenancy = App(self, "tenancy")
         self.users = App(self, "users")
+        self.virtualization = App(self, "virtualization")
+        self.vpn = App(self, "vpn")
         self.wireless = App(self, "wireless")
         self.plugins = PluginsApp(self)
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to pynetbox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #595

<!--
    Please include a summary of the proposed changes below.
-->

Adds support for `vpn` app.

Before this patch:

```
>>> nb.version
'3.7'
>>> list(nb.vpn.tunnels.filter())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'Api' object has no attribute 'vpn'
>>>
```

After this patch:

```
>>> list(nb.vpn.tunnels.filter())
[Tunnel1]
>>>
```
