### PR TITLE
Relax upper limit of packaging version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.20.0,<3.0
-packaging<24.0
+packaging

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     long_description_content_type='text/markdown',
     install_requires=[
         "requests>=2.20.0,<3.0",
-        "packaging<24.0"
+        "packaging"
     ],
     zip_safe=False,
     keywords=["netbox"],


### PR DESCRIPTION
It seems to me that pynetbox should work with packaging 24 but I'm not able to run all tests because I don't have docker installed.