### PR TITLE
Include Auth Token when Getting API Version

### DIFF
--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -109,6 +109,7 @@ class Api:
         """
         version = Request(
             base=self.base_url,
+            token=self.token,
             http_session=self.http_session,
         ).get_version()
         return version
@@ -132,6 +133,7 @@ class Api:
         """
         return Request(
             base=self.base_url,
+            token=self.token,
             http_session=self.http_session,
         ).get_openapi()
 

--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import requests
 
 from pynetbox.core.query import Request

--- a/pynetbox/core/app.py
+++ b/pynetbox/core/app.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 from pynetbox.core.endpoint import Endpoint
 from pynetbox.core.query import Request
 from pynetbox.models import (

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 from pynetbox.core.query import Request, RequestError
 from pynetbox.core.response import Record, RecordSet
 

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import concurrent.futures as cf
 import json
 from packaging import version

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -185,9 +185,9 @@ class Request:
         :Returns: Version number as a string. Empty string if version is not
         present in the headers.
         """
-        headers = {
-            "Content-Type": "application/json",
-        }
+        headers = {"Content-Type": "application/json"}
+        if self.token:
+            headers["authorization"] = "Token {}".format(self.token)
         req = self.http_session.get(
             self.normalize_url(self.base),
             headers=headers,

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -157,7 +157,8 @@ class Request:
             "Accept": "application/json",
             "Content-Type": "application/json",
         }
-
+        if self.token:
+            headers["authorization"] = "Token {}".format(self.token)
         current_version = version.parse(self.get_version())
         if current_version >= version.parse("3.5"):
             req = self.http_session.get(

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import copy
 from collections import OrderedDict
 

--- a/pynetbox/models/circuits.py
+++ b/pynetbox/models/circuits.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 from pynetbox.core.response import Record
 
 

--- a/pynetbox/models/dcim.py
+++ b/pynetbox/models/dcim.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 from urllib.parse import urlsplit
 
 from pynetbox.core.query import Request

--- a/pynetbox/models/extras.py
+++ b/pynetbox/models/extras.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 from pynetbox.core.response import Record, JsonField
 
 

--- a/pynetbox/models/ipam.py
+++ b/pynetbox/models/ipam.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 from pynetbox.core.response import Record
 from pynetbox.core.endpoint import DetailEndpoint
 

--- a/pynetbox/models/users.py
+++ b/pynetbox/models/users.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 from pynetbox.core.response import Record, JsonField
 
 

--- a/pynetbox/models/virtualization.py
+++ b/pynetbox/models/virtualization.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 from pynetbox.core.response import Record, JsonField
 from pynetbox.models.ipam import IpAddresses
 

--- a/pynetbox/models/wireless.py
+++ b/pynetbox/models/wireless.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 from pynetbox.core.response import Record
 
 


### PR DESCRIPTION
### Fixes: #612

When we get the API version, we aren't including the auth token if we have one, and as a result the request fails (as of Netbox 4.0.0).

I simply copied the header-building from `get_status` below to make sure I was following the convention, since it does exactly what we'd like.

I tested this locally and it resolved my issue, but I haven't tested it fully throughout our API integrations (as I imagine there will be more as we move to Netbox 4.0.0) so I'm not sure if there are any other side effects I haven't considered.

