### PR TITLE
core/response.py: avoid _endpoint_from_url if url is empty

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -284,7 +284,7 @@ class Record:
         self.default_ret = Record
         self.endpoint = (
             self._endpoint_from_url(values["url"])
-            if values and "url" in values
+            if values and "url" in values and values["url"]
             else endpoint
         )
         if values:


### PR DESCRIPTION
Hi folks!

First pull request for me so please be patient :)

When testing pynetbox with Netbox 4's API, I got the following error:
```
line 436, in _endpoint_from_url
    split_url_path = url_path.split("/")
TypeError: a bytes-like object is required, not 'str'
```
With some logging it was clear that `url_path` was `b''`, and in turn "path" itself was `b''` as well.

The caller seemed to be:
```
line 286, in __init__
    self._endpoint_from_url(values["url"])
```
Adding more debugging to `__init__` led to the following dump of the `values` dict:
```
{'obj': None, 'url': None, 'time': '2024-07-31T12:41:33.339876+00:00',
 'status': 'success',
 'message': 'Generated successfully, see the output tab for result.'}
```
I am not 100% sure th origin of that dict, but it should be safer to test `values["url"]` for None/empty values before calling _endpoint_from_url.
