### PR TITLE
API token is passed to retrieve NetBox version

### DIFF
--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -110,6 +110,7 @@ class Api:
         """
         version = Request(
             base=self.base_url,
+            token=self.token,
             http_session=self.http_session,
         ).get_version()
         return version


### PR DESCRIPTION
### Fixes: #640 

- Updated the `version` property in `pynetbox/core/api.py` to pass the API token when calling `get_version`.
- No problem raised even if the token is None
- This change addresses the issue where `nb.version` returns an empty string when using an OIDC proxy, due to unauthorized requests being redirected to the login page.

Closes #640 
