### PR TITLE
Draft: Speed improvements

### DIFF
--- a/pynetbox/core/app.py
+++ b/pynetbox/core/app.py
@@ -41,6 +41,7 @@ class App:
         self.api = api
         self.name = name
         self._setmodel()
+        self._cached_endpoints = {}
 
     models = {
         "dcim": dcim,
@@ -63,7 +64,11 @@ class App:
         self._setmodel()
 
     def __getattr__(self, name):
-        return Endpoint(self.api, self, name, model=self.model)
+        if name not in self._cached_endpoints:
+            self._cached_endpoints[name] = Endpoint(
+                self.api, self, name, model=self.model
+            )
+        return self._cached_endpoints[name]
 
     def config(self):
         """Returns config response from app
@@ -103,6 +108,7 @@ class PluginsApp:
 
     def __init__(self, api):
         self.api = api
+        self._cached_apps = {}
 
     def __getstate__(self):
         return self.__dict__
@@ -111,7 +117,11 @@ class PluginsApp:
         self.__dict__.update(d)
 
     def __getattr__(self, name):
-        return App(self.api, "plugins/{}".format(name.replace("_", "-")))
+        if name not in self._cached_apps:
+            self._cached_apps[name] = App(
+                self.api, "plugins/{}".format(name.replace("_", "-"))
+            )
+        return self._cached_apps[name]
 
     def installed_plugins(self):
         """Returns raw response with installed plugins

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -637,8 +637,8 @@ class Endpoint:
 
         if any(i in RESERVED_KWARGS for i in kwargs):
             raise ValueError(
-                "A reserved {} kwarg was passed. Please remove it " 
-                "try again.".format(RESERVED_KWARGS)
+                "A reserved kwarg was passed ({}). Please remove it "
+                "and try again.".format(RESERVED_KWARGS)
             )
 
         ret = Request(

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -637,9 +637,8 @@ class Endpoint:
 
         if any(i in RESERVED_KWARGS for i in kwargs):
             raise ValueError(
-                "A reserved {} kwarg was passed. Please remove it " "try again.".format(
-                    RESERVED_KWARGS
-                )
+                "A reserved {} kwarg was passed. Please remove it " 
+                "try again.".format(RESERVED_KWARGS)
             )
 
         ret = Request(

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -53,6 +53,7 @@ class Endpoint:
             endpoint=self.name,
         )
         self._choices = None
+        self._cache = None
 
     def _lookup_ret_obj(self, name, model):
         """Loads unique Response objects.
@@ -636,8 +637,9 @@ class Endpoint:
 
         if any(i in RESERVED_KWARGS for i in kwargs):
             raise ValueError(
-                "A reserved {} kwarg was passed. Please remove it "
-                "try again.".format(RESERVED_KWARGS)
+                "A reserved {} kwarg was passed. Please remove it " "try again.".format(
+                    RESERVED_KWARGS
+                )
             )
 
         ret = Request(

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from collections import OrderedDict
-
 from pynetbox.core.query import Request, RequestError
 from pynetbox.core.response import Record, RecordSet
 
@@ -36,10 +34,13 @@ class CachedRecordRegistry:
         """
         Retrieves a record from the cache
         """
-        object_cache = self._cache.get(object_type)
-        if object_cache is None:
+        if not (object_cache := self._cache.get(object_type)):
             return None
-        return object_cache.get(key, None)
+        if object := object_cache.get(key, None):
+            self._hit += 1
+            return object
+        self._miss += 1
+        return None
 
     def set(self, object_type, key, value):
         """
@@ -83,8 +84,6 @@ class Endpoint:
             endpoint=self.name,
         )
         self._choices = None
-        self._attribute_type_map = {}
-        self._attribute_endpoint_map = {}
         self._init_cache()
 
     def _init_cache(self):

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -378,13 +378,10 @@ class Record:
                     value = [list_item_parser(item) for item in value]
                 else:
                     lookup = getattr(self.__class__, key_name, None)
-                    if not isinstance(lookup, list):
-                        # This is *list_parser*, so if the custom model field is not
-                        # a list (or is not defined), just return the default model
-                        value = [self.default_ret(i, self.api, None) for i in value]
-                    else:
-                        model = lookup[0]
-                        value = [model(i, self.api, None) for i in value]
+                    # This is *list_parser*, so if the custom model field is not
+                    # a list (or is not defined), just return the default model
+                    model = lookup[0] if isinstance(lookup, list) else self.default_ret
+                    value = [model(i, self.api, None) for i in value]
             return value, [*value]
 
         def parse_value(key_name, value):

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -17,7 +17,6 @@ limitations under the License.
 import marshal
 from collections import OrderedDict
 
-import pynetbox.core.app
 from pynetbox.core.query import Request
 from pynetbox.core.util import Hashabledict
 
@@ -29,16 +28,7 @@ def get_return(record):
     """
     Used to return a "simple" representation of objects and collections.
     """
-    return_fields = ["id", "value"]
-
-    if not isinstance(record, Record):
-        raise ValueError
-
-    for i in return_fields:
-        if value := getattr(record, i, None):
-            return value
-    else:
-        return str(record)
+    return getattr(record, "id", None) or getattr(record, "value", None) or str(record)
 
 
 def flatten_custom(custom_dict):

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -144,9 +144,6 @@ class RecordSet:
             self._clear_endpoint_cache()
             raise
 
-    def __del__(self):
-        self._clear_endpoint_cache()
-
     def _init_endpoint_cache(self):
         self.endpoint._cache = CachedRecordRegistry(self.endpoint.api)
 

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -388,12 +388,12 @@ class Record:
             return value, [*value]
 
         def parse_value(key_name, value):
-            if not isinstance(value, (dict, list)):
-                to_cache = value
-            elif isinstance(value, dict):
+            if isinstance(value, dict):
                 value, to_cache = dict_parser(key_name, value)
             elif isinstance(value, list):
                 value, to_cache = list_parser(key_name, value)
+            else:
+                to_cache = value
             setattr(self, key_name, value)
             return to_cache
 

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -70,6 +70,8 @@ class CachedRecordRegistry:
     def __init__(self, api):
         self.api = api
         self._cache = {}
+        self._hit = 0
+        self._miss = 0
 
     def get(self, object_type, key):
         """
@@ -142,8 +144,8 @@ class RecordSet:
             self._clear_endpoint_cache()
             raise
 
-    # def __del__(self):
-    #     self._clear_endpoint_cache()
+    def __del__(self):
+        self._clear_endpoint_cache()
 
     def _init_endpoint_cache(self):
         self.endpoint._cache = CachedRecordRegistry(self.endpoint.api)
@@ -389,17 +391,22 @@ class Record:
         else:
             return getattr(getattr(self.api, app), name)
 
-    def _get_or_init(self, object_type, key, value, model):
+    def _get_or_init(self, object_type, value, model):
         """
         Returns a record from the endpoint cache if it exists, otherwise
         initializes a new record, store it in the cache, and return it.
         """
-        if self._endpoint and self._endpoint._cache:
+        key = (
+            value.get("url", None) or value.get("id", None) or value.get("value", None)
+        )
+        if key and self._endpoint and self._endpoint._cache:
             if cached := self._endpoint._cache.get(object_type, key):
+                self._endpoint._cache._hit += 1
                 return cached
         model = model or Record
         record = model(value, self.api, None)
-        if self._endpoint and self._endpoint._cache:
+        if key and self._endpoint and self._endpoint._cache:
+            self._endpoint._cache._miss += 1
             self._endpoint._cache.set(object_type, key, record)
         return record
 
@@ -417,7 +424,7 @@ class Record:
                 lookup = getattr(self.__class__, key_name, None)
                 if lookup is None or not issubclass(lookup, JsonField):
                     fkey = get_foreign_key(value)
-                    value = self._get_or_init(key_name, fkey, value, lookup)
+                    value = self._get_or_init(key_name, value, lookup)
                     return value, fkey
             return value, marshal.loads(marshal.dumps(value))
 
@@ -426,8 +433,7 @@ class Record:
 
             lookup = list_item["object_type"]
             if model := CONTENT_TYPE_MAPPER.get(lookup, None):
-                fkey = get_foreign_key(list_item["object"])
-                value = self._get_or_init(lookup, fkey, list_item["object"], model)
+                value = self._get_or_init(lookup, list_item["object"], model)
                 return value
             return list_item
 
@@ -447,10 +453,7 @@ class Record:
                     # This is *list_parser*, so if the custom model field is not
                     # a list (or is not defined), just return the default model
                     model = lookup[0] if isinstance(lookup, list) else self.default_ret
-                    value = [
-                        self._get_or_init(key_name, get_foreign_key(i), i, model)
-                        for i in value
-                    ]
+                    value = [self._get_or_init(key_name, i, model) for i in value]
             return value, [*value]
 
         def parse_value(key_name, value):

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -264,11 +264,8 @@ class Record:
         self._init_cache = []
         self.api = api
         self.default_ret = Record
-        self.endpoint = (
-            self._endpoint_from_url(values["url"])
-            if values and "url" in values and values["url"]
-            else endpoint
-        )
+        self.url = values.get("url", None) if values else None
+        self._endpoint = endpoint
         if values:
             self._parse_values(values)
 
@@ -336,6 +333,22 @@ class Record:
             return self.__key__() == other.__key__()
         return NotImplemented
 
+    @property
+    def endpoint(self):
+        if self._endpoint is None:
+            self._endpoint = self._endpoint_from_url()
+        return self._endpoint
+
+    def _endpoint_from_url(self):
+        url_path = self.url.replace(self.api.base_url, "").split("/")
+        is_plugin = url_path and url_path[1] == "plugins"
+        start = 2 if is_plugin else 1
+        app, name = [i.replace("-", "_") for i in url_path[start : start + 2]]
+        if is_plugin:
+            return getattr(getattr(self.api.plugins, app), name)
+        else:
+            return getattr(getattr(self.api, app), name)
+
     def _parse_values(self, values):
         """Parses values init arg.
 
@@ -349,7 +362,7 @@ class Record:
                 lookup = getattr(self.__class__, key_name, None)
                 if lookup is None or not issubclass(lookup, JsonField):
                     # If we have a custom model field, use it, otherwise use a default Record model
-                    args = [value, self.api, self.endpoint]
+                    args = [value, self.api, None]
                     value = lookup(*args) if lookup else self.default_ret(*args)
                     return value, get_return(value)
             return value, marshal.loads(marshal.dumps(value))
@@ -359,7 +372,7 @@ class Record:
 
             lookup = list_item["object_type"]
             if model := CONTENT_TYPE_MAPPER.get(lookup, None):
-                return model(list_item["object"], self.api, self.endpoint)
+                return model(list_item["object"], self.api, None)
             return list_item
 
         def list_parser(key_name, value):
@@ -378,12 +391,10 @@ class Record:
                     if not isinstance(lookup, list):
                         # This is *list_parser*, so if the custom model field is not
                         # a list (or is not defined), just return the default model
-                        value = [
-                            self.default_ret(i, self.api, self.endpoint) for i in value
-                        ]
+                        value = [self.default_ret(i, self.api, None) for i in value]
                     else:
                         model = lookup[0]
-                        value = [model(i, self.api, self.endpoint) for i in value]
+                        value = [model(i, self.api, None) for i in value]
             return value, [*value]
 
         def parse_value(key_name, value):
@@ -397,16 +408,6 @@ class Record:
             return to_cache
 
         self._init_cache = [(k, parse_value(k, v)) for k, v in values.items()]
-
-    def _endpoint_from_url(self, url):
-        url_path = url.replace(self.api.base_url, "").split("/")
-        is_plugin = url_path and url_path[1] == "plugins"
-        start = 2 if is_plugin else 1
-        app, name = [i.replace("-", "_") for i in url_path[start : start + 2]]
-        if is_plugin:
-            return getattr(getattr(self.api.plugins, app), name)
-        else:
-            return getattr(getattr(self.api, app), name)
 
     def full_details(self):
         """Queries the hyperlinked endpoint if 'url' is defined.

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -399,13 +399,13 @@ class Record:
         self._init_cache = [(k, parse_value(k, v)) for k, v in values.items()]
 
     def _endpoint_from_url(self, url):
-        url_path = url.replace(self.api.base_url, "")
-        split_url_path = url_path.split("/")
-        if split_url_path[1] == "plugins":
-            app, name = split_url_path[2:4]
-            return getattr(getattr(getattr(self.api, "plugins"), app), name)
+        url_path = url.replace(self.api.base_url, "").split("/")
+        is_plugin = url_path and url_path[1] == "plugins"
+        start = 2 if is_plugin else 1
+        app, name = [i.replace("-", "_") for i in url_path[start : start + 2]]
+        if is_plugin:
+            return getattr(getattr(self.api.plugins, app), name)
         else:
-            app, name = split_url_path[1:3]
             return getattr(getattr(self.api, app), name)
 
     def full_details(self):
@@ -569,7 +569,7 @@ class Record:
         """Deletes an existing object.
 
         :returns: True if DELETE operation was successful.
-        :example:
+        :examples:
 
         >>> x = nb.dcim.devices.get(name='test1-a3-tor1b')
         >>> x.delete()

--- a/pynetbox/models/dcim.py
+++ b/pynetbox/models/dcim.py
@@ -151,6 +151,7 @@ class InterfaceConnection(Record):
 
 
 class Interfaces(TraceableRecord):
+    device = Devices
     interface_connection = InterfaceConnection
 
 

--- a/pynetbox/models/mapper.py
+++ b/pynetbox/models/mapper.py
@@ -109,3 +109,5 @@ CONTENT_TYPE_MAPPER = {
     "wireless.WirelessLANGroup": None,
     "wireless.wirelesslink": None,
 }
+
+TYPE_CONTENT_MAPPER = {v: k for k, v in CONTENT_TYPE_MAPPER.items() if v is not None}

--- a/tests/fixtures/users/permission.json
+++ b/tests/fixtures/users/permission.json
@@ -4,7 +4,8 @@
     "users": [
         {
             "id": 1,
-            "username": "user1"
+            "username": "user1",
+            "url": "http://localhost:8000/api/users/users/1/"
         }
     ],
     "constraints": [

--- a/tests/fixtures/users/permission.json
+++ b/tests/fixtures/users/permission.json
@@ -3,6 +3,7 @@
     "name": "permission1",
     "users": [
         {
+            "id": 1,
             "username": "user1"
         }
     ],

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -26,8 +26,13 @@ class RecordTestCase(unittest.TestCase):
         test_values = {
             "id": 123,
             "units": 12,
-            "nested_dict": {"id": 222, "name": "bar"},
+            "nested_dict": {
+                "id": 222,
+                "name": "bar",
+                "url": "http://localhost:8000/api/test-app/test-endpoint/222/",
+            },
             "int_list": [123, 321, 231],
+            "url": "http://localhost:8000/api/test-app/test-endpoint/123/",
         }
         test_obj = Record(test_values, None, None)
         self.assertEqual(test_obj.id, 123)

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -225,6 +225,7 @@ class RecordTestCase(unittest.TestCase):
         endpoint = Mock()
         endpoint.name = "test-endpoint"
         endpoint.url = "http://localhost:8080/api/test-app/test-endpoint/"
+        endpoint._cache = None
         api.test_app = Mock()
         api.test_app.test_endpoint = endpoint
         test = Record(
@@ -254,6 +255,7 @@ class RecordTestCase(unittest.TestCase):
         endpoint = Mock()
         endpoint.name = "test-endpoint"
         endpoint.url = "http://localhost:8080/testing/api/test-app/test-endpoint/"
+        endpoint._cache = None
         api.test_app = Mock()
         api.test_app.test_endpoint = endpoint
         test = Record(

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -230,7 +230,8 @@ class RecordTestCase(unittest.TestCase):
         endpoint = Mock()
         endpoint.name = "test-endpoint"
         endpoint.url = "http://localhost:8080/api/test-app/test-endpoint/"
-        endpoint._cache = None
+        endpoint._cache = Mock()
+        endpoint._cache.get = Mock(return_value=None)
         api.test_app = Mock()
         api.test_app.test_endpoint = endpoint
         test = Record(
@@ -248,6 +249,8 @@ class RecordTestCase(unittest.TestCase):
         )
         test.child.name = "test321"
         test.child.save()
+        print(api)
+        print(api.http_session)
         self.assertEqual(
             api.http_session.patch.call_args[0][0],
             "http://localhost:8080/api/test-app/test-endpoint/321/",
@@ -260,7 +263,8 @@ class RecordTestCase(unittest.TestCase):
         endpoint = Mock()
         endpoint.name = "test-endpoint"
         endpoint.url = "http://localhost:8080/testing/api/test-app/test-endpoint/"
-        endpoint._cache = None
+        endpoint._cache = Mock()
+        endpoint._cache.get = Mock(return_value=None)
         api.test_app = Mock()
         api.test_app.test_endpoint = endpoint
         test = Record(

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -291,7 +291,7 @@ class RecordTestCase(unittest.TestCase):
             api,
             None,
         )
-        ret = test._endpoint_from_url(test.url)
+        ret = test._endpoint_from_url()
         self.assertEqual(ret.name, "test-endpoint")
 
     def test_endpoint_from_url_with_directory_in_base_url(self):
@@ -309,7 +309,7 @@ class RecordTestCase(unittest.TestCase):
             api,
             None,
         )
-        ret = test._endpoint_from_url(test.url)
+        ret = test._endpoint_from_url()
         self.assertEqual(ret.name, "test-endpoint")
 
     def test_endpoint_from_url_with_plugins(self):
@@ -328,7 +328,7 @@ class RecordTestCase(unittest.TestCase):
             api,
             None,
         )
-        ret = test._endpoint_from_url(test.url)
+        ret = test._endpoint_from_url()
         self.assertEqual(ret.name, "test-endpoint")
 
     def test_endpoint_from_url_with_plugins_and_directory_in_base_url(self):
@@ -347,7 +347,7 @@ class RecordTestCase(unittest.TestCase):
             api,
             None,
         )
-        ret = test._endpoint_from_url(test.url)
+        ret = test._endpoint_from_url()
         self.assertEqual(ret.name, "test-endpoint")
 
     def test_serialize_tag_list_order(self):

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -219,11 +219,14 @@ class RecordTestCase(unittest.TestCase):
         self.assertEqual(test1, test2)
 
     def test_nested_write(self):
-        app = Mock()
-        app.token = "abc123"
-        app.base_url = "http://localhost:8080/api"
+        api = Mock()
+        api.token = "abc123"
+        api.base_url = "http://localhost:8080/api"
         endpoint = Mock()
         endpoint.name = "test-endpoint"
+        endpoint.url = "http://localhost:8080/api/test-app/test-endpoint/"
+        api.test_app = Mock()
+        api.test_app.test_endpoint = endpoint
         test = Record(
             {
                 "id": 123,
@@ -234,22 +237,25 @@ class RecordTestCase(unittest.TestCase):
                     "url": "http://localhost:8080/api/test-app/test-endpoint/321/",
                 },
             },
-            app,
+            api,
             endpoint,
         )
         test.child.name = "test321"
         test.child.save()
         self.assertEqual(
-            app.http_session.patch.call_args[0][0],
+            api.http_session.patch.call_args[0][0],
             "http://localhost:8080/api/test-app/test-endpoint/321/",
         )
 
     def test_nested_write_with_directory_in_base_url(self):
-        app = Mock()
-        app.token = "abc123"
-        app.base_url = "http://localhost:8080/testing/api"
+        api = Mock()
+        api.token = "abc123"
+        api.base_url = "http://localhost:8080/testing/api"
         endpoint = Mock()
         endpoint.name = "test-endpoint"
+        endpoint.url = "http://localhost:8080/testing/api/test-app/test-endpoint/"
+        api.test_app = Mock()
+        api.test_app.test_endpoint = endpoint
         test = Record(
             {
                 "id": 123,
@@ -260,19 +266,22 @@ class RecordTestCase(unittest.TestCase):
                     "url": "http://localhost:8080/testing/api/test-app/test-endpoint/321/",
                 },
             },
-            app,
+            api,
             endpoint,
         )
         test.child.name = "test321"
         test.child.save()
         self.assertEqual(
-            app.http_session.patch.call_args[0][0],
+            api.http_session.patch.call_args[0][0],
             "http://localhost:8080/testing/api/test-app/test-endpoint/321/",
         )
 
     def test_endpoint_from_url(self):
         api = Mock()
         api.base_url = "http://localhost:8080/api"
+        api.test_app = Mock()
+        api.test_app.test_endpoint = Mock()
+        api.test_app.test_endpoint.name = "test-endpoint"
         test = Record(
             {
                 "id": 123,
@@ -288,6 +297,9 @@ class RecordTestCase(unittest.TestCase):
     def test_endpoint_from_url_with_directory_in_base_url(self):
         api = Mock()
         api.base_url = "http://localhost:8080/testing/api"
+        api.test_app = Mock()
+        api.test_app.test_endpoint = Mock()
+        api.test_app.test_endpoint.name = "test-endpoint"
         test = Record(
             {
                 "id": 123,
@@ -303,6 +315,10 @@ class RecordTestCase(unittest.TestCase):
     def test_endpoint_from_url_with_plugins(self):
         api = Mock()
         api.base_url = "http://localhost:8080/api"
+        api.plugins = Mock()
+        api.plugins.test_app = Mock()
+        api.plugins.test_app.test_endpoint = Mock()
+        api.plugins.test_app.test_endpoint.name = "test-endpoint"
         test = Record(
             {
                 "id": 123,
@@ -318,6 +334,10 @@ class RecordTestCase(unittest.TestCase):
     def test_endpoint_from_url_with_plugins_and_directory_in_base_url(self):
         api = Mock()
         api.base_url = "http://localhost:8080/testing/api"
+        api.plugins = Mock()
+        api.plugins.test_app = Mock()
+        api.plugins.test_app.test_endpoint = Mock()
+        api.plugins.test_app.test_endpoint.name = "test-endpoint"
         test = Record(
             {
                 "id": 123,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to pynetbox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #658 #625

Various refactoring allows for a substantial increase in performance of the Record initialization.

- `_parse_values` was heavily refactored to avoid multiple similar checks and unnecessary processing
- in turn, `get_return` now only needs to work on `Record` object and drops legacy code from Netbox 2.7
- `_endpoint_from_url` can work with string instead of using the `urlsplit` library
- finally caching of apps/endpoints avoid constant reinstantiation of similar objects

