### PR TITLE
Fix return object lookup and improve tests

### DIFF
--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -42,8 +42,8 @@ class Endpoint:
     """
 
     def __init__(self, api, app, name, model=None):
-        self.return_obj = self._lookup_ret_obj(name, model)
         self.name = name.replace("_", "-")
+        self.return_obj = self._lookup_ret_obj(model)
         self.api = api
         self.base_url = api.base_url
         self.token = api.token
@@ -54,7 +54,7 @@ class Endpoint:
         )
         self._choices = None
 
-    def _lookup_ret_obj(self, name, model):
+    def _lookup_ret_obj(self, model):
         """Loads unique Response objects.
 
         This method loads a unique response object for an endpoint if
@@ -67,7 +67,7 @@ class Endpoint:
         :Returns: Record (obj)
         """
         if model:
-            name = name.title().replace("_", "")
+            name = self.name.title().replace("-", "")
             ret = getattr(model, name, Record)
         else:
             ret = Record
@@ -636,8 +636,8 @@ class Endpoint:
 
         if any(i in RESERVED_KWARGS for i in kwargs):
             raise ValueError(
-                "A reserved {} kwarg was passed. Please remove it "
-                "try again.".format(RESERVED_KWARGS)
+                "A reserved kwarg was passed ({}). Please remove it "
+                "and try again.".format(RESERVED_KWARGS)
             )
 
         ret = Request(

--- a/tests/integration/test_dcim.py
+++ b/tests/integration/test_dcim.py
@@ -2,6 +2,7 @@ import pytest
 from packaging import version
 
 import pynetbox
+import pynetbox.models.dcim
 
 
 @pytest.fixture(scope="module")
@@ -181,6 +182,7 @@ class TestInterface(BaseTest):
         ret = api.dcim.interfaces.create(
             name="test-interface", type="1000base-t", device=device.id
         )
+        assert isinstance(ret, pynetbox.models.dcim.Interfaces)
         yield ret
         ret.delete()
 
@@ -213,12 +215,14 @@ class TestPowerCable(BaseTest):
                 site=site.id,
             )
         outlet = api.dcim.power_outlets.create(name="outlet", device=pdu.id)
+        assert isinstance(outlet, pynetbox.models.dcim.PowerOutlets)
         yield outlet
         pdu.delete()
 
     @pytest.fixture(scope="class")
     def power_port(self, api, device):
         ret = api.dcim.power_ports.create(name="PSU1", device=device.id)
+        assert isinstance(ret, pynetbox.models.dcim.PowerPorts)
         yield ret
 
     @pytest.fixture(scope="class")
@@ -231,6 +235,7 @@ class TestPowerCable(BaseTest):
                 {"object_type": "dcim.poweroutlet", "object_id": power_outlet.id},
             ],
         )
+        assert isinstance(cable, pynetbox.models.dcim.Cables)
         yield cable
         cable.delete()
 
@@ -263,12 +268,14 @@ class TestConsoleCable(BaseTest):
                 site=site.id,
             )
         ret = api.dcim.console_server_ports.create(name="Port 1", device=device.id)
+        assert isinstance(ret, pynetbox.models.dcim.ConsoleServerPorts)
         yield ret
         device.delete()
 
     @pytest.fixture(scope="class")
     def console_port(self, api, device):
         ret = api.dcim.console_ports.create(name="Console", device=device.id)
+        assert isinstance(ret, pynetbox.models.dcim.ConsolePorts)
         yield ret
 
     @pytest.fixture(scope="class")
@@ -284,6 +291,7 @@ class TestConsoleCable(BaseTest):
                 },
             ],
         )
+        assert isinstance(ret, pynetbox.models.dcim.Cables)
         yield ret
         ret.delete()
 
@@ -318,6 +326,7 @@ class TestInterfaceCable(BaseTest):
         ret = api.dcim.interfaces.create(
             name="Ethernet1", type="1000base-t", device=device.id
         )
+        assert isinstance(ret, pynetbox.models.dcim.Interfaces)
         yield ret
         device.delete()
 
@@ -338,6 +347,7 @@ class TestInterfaceCable(BaseTest):
                 {"object_type": "dcim.interface", "object_id": interface_b.id},
             ],
         )
+        assert isinstance(ret, pynetbox.models.dcim.Cables)
         yield ret
         ret.delete()
 

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 
 import pynetbox
+import pynetbox.models.circuits
 
 from .util import Response
 
@@ -76,6 +77,7 @@ class Generic:
 
 class CircuitsTestCase(Generic.Tests):
     name = "circuits"
+    ret = pynetbox.models.circuits.Circuits
 
     @patch(
         "requests.sessions.Session.get",
@@ -96,6 +98,7 @@ class CircuitTypeTestCase(Generic.Tests):
 
 class CircuitTerminationsTestCase(Generic.Tests):
     name = "circuit_terminations"
+    ret = pynetbox.models.circuits.CircuitTerminations
 
     @patch(
         "requests.sessions.Session.get",

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 
 import pynetbox
+import pynetbox.models.users
 
 from .util import Response
 
@@ -76,6 +77,7 @@ class Generic:
 
 class UsersTestCase(Generic.Tests):
     name = "users"
+    ret = pynetbox.models.users.Users
 
     @patch(
         "requests.sessions.Session.get",
@@ -93,6 +95,7 @@ class GroupsTestCase(Generic.Tests):
 
 class PermissionsTestCase(Generic.Tests):
     name = "permissions"
+    ret = pynetbox.models.users.Permissions
 
     @patch(
         "requests.sessions.Session.get",

--- a/tests/test_virtualization.py
+++ b/tests/test_virtualization.py
@@ -2,6 +2,8 @@ import unittest
 from unittest.mock import patch
 
 import pynetbox
+import pynetbox.models
+import pynetbox.models.virtualization
 
 from .util import Response
 
@@ -88,6 +90,7 @@ class ClustersTestCase(Generic.Tests):
 
 class VirtualMachinesTestCase(Generic.Tests):
     name = "virtual_machines"
+    ret = pynetbox.models.virtualization.VirtualMachines
 
 
 class InterfacesTestCase(Generic.Tests):

--- a/tests/test_wireless.py
+++ b/tests/test_wireless.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 
 import pynetbox
+import pynetbox.models.wireless
 
 from .util import Response
 
@@ -74,6 +75,7 @@ class Generic:
 
 class WirelessLansTestCase(Generic.Tests):
     name = "wireless_lans"
+    ret = pynetbox.models.wireless.WirelessLans
 
     @patch(
         "requests.sessions.Session.get",


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to pynetbox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #660 

The return object lookup in `Endpoint` class fails for endpoints with a dash, and falls back to returning a `Record` object instead of the correct Model.

Tests have also been fixed to catch this.