### PR TITLE
Fix cable serialize

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -643,7 +643,7 @@ class GenericListObject:
         return getattr(self.object, k)
 
     def __iter__(self):
-        for i in dir(self):
+        for i in ["object_id", "object_type", "object"]:
             cur_attr = getattr(self, i)
             if isinstance(cur_attr, Record):
                 cur_attr = dict(cur_attr)

--- a/pynetbox/models/mapper.py
+++ b/pynetbox/models/mapper.py
@@ -109,3 +109,5 @@ CONTENT_TYPE_MAPPER = {
     "wireless.WirelessLANGroup": None,
     "wireless.wirelesslink": None,
 }
+
+TYPE_CONTENT_MAPPER = {v: k for k, v in CONTENT_TYPE_MAPPER.items() if v is not None}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to pynetbox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #555 

The way `pynetbox` currently handles mixed lists doesn't allow to re-instantiate the proper nested object types when loading values from a serialized() object. This is because the generic_list_parser "gobbles" that information by construction specific Record types from the mixed list.

Example:
```python
>>> print(cable.serialize())

{'a_terminations': [530082],
 'b_terminations': [314260],
 'color': '',
 'comments': '',
 'created': '2022-05-03T02:00:00+02:00',
 'custom_fields': {},
 'description': '',
 'display': '1001',
 'id': 155652,
 'label': '1001',
 'last_updated': '2022-06-29T14:36:49.386886+02:00',
 'length': None,
 'length_unit': None,
 'status': 'connected',
 'tags': [],
 'tenant': 2510,
 'type': '',
 'url': 'https://localhost:8000/api/dcim/cables/155652/'}
 ```
Patching the record `a_terminations` / `b_terminations` with new ID wouldn't work as with other nested Record types as in this case the API expects a dict with `object_type` and `object_id` keys.

I propose to solve this by introducing a `GenericListItem` class that more accurately stores the state of the API response, while allowing a nicer serialization

```python
>>> print(cable.serialize())

 {'a_terminations': [{'object_id': 530082, 'object_type': 'dcim.interface'}],
 'b_terminations': [{'object_id': 314260, 'object_type': 'dcim.frontport'}],
 'color': '',
 'comments': '',
 'created': '2022-05-03T02:00:00+02:00',
 'custom_fields': {},
 'description': '',
 'display': '1001',
 'id': 155652,
 'label': '1001',
 'last_updated': '2022-06-29T14:36:49.386886+02:00',
 'length': None,
 'length_unit': None,
 'status': 'connected',
 'tags': [],
 'tenant': 2510,
 'type': '',
 'url': 'https://localhost:8000/api/dcim/cables/155652/'}
```
The `__getattr__` on the new class, allows to maintain backward compatibility to some extent.
```python
>>> print(cables.a_terminations[0].label)
'ETH-1'
```

This involves a change in type of objects returned in mixed/generic lists now always being `GenericListItem` 
