### PR TITLE
#677 update issue templates for triage labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,7 +1,7 @@
 ---
 name: 🐛 Bug Report
 description: Report a reproducible bug in the current release of pynetbox
-labels: ["type: bug"]
+labels: ["type: bug", "status: needs triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation_change.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation_change.yaml
@@ -1,7 +1,7 @@
 ---
 name: 📖 Documentation Change
 description: Suggest an addition or modification to the pynetbox documentation
-labels: ["type: documentation"]
+labels: ["type: documentation", "status: needs triage"]
 body:
   - type: dropdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,7 +1,7 @@
 ---
 name: ✨ Feature Request
 description: Propose a new pynetbox feature or enhancement
-labels: ["type: feature"]
+labels: ["type: feature", "status: needs triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
### Fixes: #677

Updates the issue templates to include the needs triage flags.