### PR TITLE
#677 update issue templates for triage labels

### DIFF
--- a/.github/workflows/py3.yml
+++ b/.github/workflows/py3.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.10", "3.11", "3.12"]
-        netbox: ["3.6", "3.7", "4.0"]
+        netbox: ["4.0", "4.1", "4.2"]
 
     steps:
       - uses: actions/checkout@v4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from urllib import parse
 import pytest
 from packaging import version
 
-DEFAULT_NETBOX_VERSIONS = "4.0"
+DEFAULT_NETBOX_VERSIONS = "4.2"
 
 
 def pytest_addoption(parser):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,12 +26,12 @@ def get_netbox_docker_version_tag(netbox_version):
     """
     major, minor = netbox_version.major, netbox_version.minor
 
-    if (major, minor) == (3, 6):
-        tag = "2.7.0"
-    elif (major, minor) == (3, 7):
-        tag = "2.8.0"
-    elif (major, minor) == (4, 0):
+    if (major, minor) == (4, 0):
         tag = "2.9.1"
+    elif (major, minor) == (4, 1):
+        tag = "3.0.2"
+    elif (major, minor) == (4, 2):
+        tag = "3.2.0"
     else:
         raise NotImplementedError(
             "Version %s is not currently supported" % netbox_version


### PR DESCRIPTION
### Fixes: #679

Update the GitHub workflow and test-configuration to use the latest versions of NetBox instead of the older 3.6, 3.7 versions which are quite out of date.