### PR TITLE
Filter validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,30 @@ nb = pynetbox.api(
     threading=True,
 )
 ```
+### Filters validation
+
+NetBox doesn't validate filters passed to the GET API endpoints, which are accessed with `.get()` and `.filter()`. If a filter is incorrect, NetBox silently returns the entire database table content. Pynetbox allows to check provided parameters against NetBox OpenAPI specification before doing the call, and raise an exception if a parameter is incorrect.
+
+This can be enabled globally by setting `strict_filters=True` in the API object initialization:
+
+```python
+nb = pynetbox.api(
+    'http://localhost:8000',
+    strict_filters=True,
+)
+```
+
+This can also be enabled and disabled on a per-request basis:
+
+```python
+# Disable for one request when enabled globally.
+# Will not raise an exception and return the entire Device table.
+nb.dcim.devices.filter(non_existing_filter="aaaa", strict_filter=False)
+
+# Enable for one request when not enabled globally.
+# Will raise an exception.
+nb.dcim.devices.filter(non_existing_filter="aaaa", strict_filter=True)
+```
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ This can also be enabled and disabled on a per-request basis:
 ```python
 # Disable for one request when enabled globally.
 # Will not raise an exception and return the entire Device table.
-nb.dcim.devices.filter(non_existing_filter="aaaa", strict_filter=False)
+nb.dcim.devices.filter(non_existing_filter="aaaa", strict_filters=False)
 
 # Enable for one request when not enabled globally.
 # Will raise an exception.
-nb.dcim.devices.filter(non_existing_filter="aaaa", strict_filter=True)
+nb.dcim.devices.filter(non_existing_filter="aaaa", strict_filters=True)
 ```
 
 ## Running Tests

--- a/pynetbox/__init__.py
+++ b/pynetbox/__init__.py
@@ -1,4 +1,9 @@
 from pynetbox.core.api import Api as api
-from pynetbox.core.query import AllocationError, ContentError, RequestError, ParameterValidationError
+from pynetbox.core.query import (
+    AllocationError,
+    ContentError,
+    RequestError,
+    ParameterValidationError,
+)
 
 __version__ = "7.5.0"

--- a/pynetbox/__init__.py
+++ b/pynetbox/__init__.py
@@ -1,4 +1,4 @@
 from pynetbox.core.api import Api as api
-from pynetbox.core.query import AllocationError, ContentError, RequestError
+from pynetbox.core.query import AllocationError, ContentError, RequestError, ParameterValidationError
 
 __version__ = "7.5.0"

--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -79,6 +79,7 @@ class Api:
         url,
         token=None,
         threading=False,
+        strict_filters=False,
     ):
         """Initialize the API client.
 
@@ -86,12 +87,14 @@ class Api:
             url (str): The base URL to the instance of NetBox you wish to connect to.
             token (str, optional): Your NetBox API token. If not provided, authentication will be required for each request.
             threading (bool, optional): Set to True to use threading in `.all()` and `.filter()` requests, defaults to False.
+            strict_filters (bool, optional): Set to True to check GET call filters against OpenAPI specifications (intentionally not done in NetBox API)
         """
         base_url = "{}/api".format(url if url[-1] != "/" else url[:-1])
         self.token = token
         self.base_url = base_url
         self.http_session = requests.Session()
         self.threading = threading
+        self.strict_filters = strict_filters
 
         # Initialize NetBox apps
         self.circuits = App(self, "circuits")
@@ -105,6 +108,11 @@ class Api:
         self.vpn = App(self, "vpn")
         self.wireless = App(self, "wireless")
         self.plugins = PluginsApp(self)
+
+        # OpenAPI specifications cache
+        self._openapi = None
+        if self.strict_filters:
+            self.openapi()
 
     @property
     def version(self):
@@ -139,6 +147,7 @@ class Api:
         """Returns the OpenAPI spec.
 
         Quick helper function to pull down the entire OpenAPI spec.
+        It is stored in memory to avoid repeated calls on NetBox API.
 
         ## Returns
         dict: The OpenAPI specification as a dictionary.
@@ -155,10 +164,12 @@ class Api:
         # {...}
         ```
         """
-        return Request(
-            base=self.base_url,
-            http_session=self.http_session,
-        ).get_openapi()
+        if not self._openapi:
+            self._openapi = Request(
+                base=self.base_url,
+                http_session=self.http_session,
+            ).get_openapi()
+        return self._openapi
 
     def status(self):
         """Gets the status information from NetBox.

--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -87,7 +87,7 @@ class Api:
             url (str): The base URL to the instance of NetBox you wish to connect to.
             token (str, optional): Your NetBox API token. If not provided, authentication will be required for each request.
             threading (bool, optional): Set to True to use threading in `.all()` and `.filter()` requests, defaults to False.
-            strict_filters (bool, optional): Set to True to check GET call filters against OpenAPI specifications (intentionally not done in NetBox API)
+            strict_filters (bool, optional): Set to True to check GET call filters against OpenAPI specifications (intentionally not done in NetBox API), defaults to False.
         """
         base_url = "{}/api".format(url if url[-1] != "/" else url[:-1])
         self.token = token
@@ -108,11 +108,6 @@ class Api:
         self.vpn = App(self, "vpn")
         self.wireless = App(self, "wireless")
         self.plugins = PluginsApp(self)
-
-        # OpenAPI specifications cache
-        self._openapi = None
-        if self.strict_filters:
-            self.openapi()
 
     @property
     def version(self):
@@ -164,12 +159,13 @@ class Api:
         # {...}
         ```
         """
-        if not self._openapi:
-            self._openapi = Request(
+        if not (openapi := getattr(self, "_openapi", None)):
+            openapi = self._openapi = Request(
                 base=self.base_url,
                 http_session=self.http_session,
             ).get_openapi()
-        return self._openapi
+
+        return openapi
 
     def status(self):
         """Gets the status information from NetBox.

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -99,7 +99,7 @@ class Endpoint:
         
         # Parse NetBox OpenAPI definition
         try:
-            openapi_path = self.openapi_path()["paths"].get(self.openapi_path)
+            openapi_path = self.api.openapi()["paths"].get(self.openapi_path)
 
             if not openapi_path:
                 raise ParameterValidationError(f"Path '{self.openapi_path}' does not exist in NetBox OpenAPI specification.")
@@ -318,7 +318,7 @@ class Endpoint:
             )
         limit = kwargs.pop("limit") if "limit" in kwargs else 0
         offset = kwargs.pop("offset") if "offset" in kwargs else None
-        strict_filters = kwargs.pop("strict_filters") if "strict_filters" else None
+        strict_filters = kwargs.pop("strict_filters") if "strict_filters" in kwargs else None
 
         if limit == 0 and offset is not None:
             raise ValueError("offset requires a positive limit value")

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -79,10 +79,10 @@ class Endpoint:
         else:
             ret = Record
         return ret
-    
-    def _validate_openapi_parameters(self, method:str, parameters:dict)->None:
+
+    def _validate_openapi_parameters(self, method: str, parameters: dict) -> None:
         """Validate GET request parameters against OpenAPI specification
-        
+
         This method raises a **ParameterValidationError** if parameters passed to NetBox API
         do not match the OpenAPI specification or validation fails.
 
@@ -96,25 +96,31 @@ class Endpoint:
         """
         if method.lower() != "get":
             raise RuntimeError(f"Unsupported method '{method}'.")
-        
+
         # Parse NetBox OpenAPI definition
         try:
             openapi_path = self.api.openapi()["paths"].get(self.openapi_path)
 
             if not openapi_path:
-                raise ParameterValidationError(f"Path '{self.openapi_path}' does not exist in NetBox OpenAPI specification.")
-            
+                raise ParameterValidationError(
+                    f"Path '{self.openapi_path}' does not exist in NetBox OpenAPI specification."
+                )
+
             openapi_parameters = openapi_path[method]["parameters"]
             allowed_parameters = [p["name"] for p in openapi_parameters]
 
         except KeyError as exc:
-            raise ParameterValidationError(f"Error while parsing Netbox OpenAPI specification: {exc}")
+            raise ParameterValidationError(
+                f"Error while parsing Netbox OpenAPI specification: {exc}"
+            )
 
         # Validate all parameters
         validation_errors = []
         for p in parameters:
             if p not in allowed_parameters:
-                validation_errors.append(f"'{p}' is not allowed as parameter on path '{self.openapi_path}'.")
+                validation_errors.append(
+                    f"'{p}' is not allowed as parameter on path '{self.openapi_path}'."
+                )
 
         if len(validation_errors) > 0:
             raise ParameterValidationError(validation_errors)
@@ -318,7 +324,9 @@ class Endpoint:
             )
         limit = kwargs.pop("limit") if "limit" in kwargs else 0
         offset = kwargs.pop("offset") if "offset" in kwargs else None
-        strict_filters = kwargs.pop("strict_filters") if "strict_filters" in kwargs else None
+        strict_filters = (
+            kwargs.pop("strict_filters") if "strict_filters" in kwargs else None
+        )
 
         if limit == 0 and offset is not None:
             raise ValueError("offset requires a positive limit value")
@@ -326,14 +334,14 @@ class Endpoint:
 
         try:
             self._validate_openapi_parameters("get", filters)
-        
+
         except ParameterValidationError as e:
             # Local strict_filters kwarg takes precedence on global strict_filters
-            if (self.api.strict_filters if strict_filters is None else strict_filters):
+            if self.api.strict_filters if strict_filters is None else strict_filters:
                 raise
             else:
                 print(e.error)
-        
+
         req = Request(
             filters=filters,
             base=self.url,

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -108,9 +108,10 @@ class ContentError(Exception):
     def __str__(self):
         return self.error
 
+
 class ParameterValidationError(Exception):
     """API parameter validation Exception.
-    
+
     Raised when filter parameters do not match Netbox OpenAPI specification.
 
     ## Examples
@@ -122,12 +123,14 @@ class ParameterValidationError(Exception):
         print(e.error)
     ```
     """
+
     def __init__(self, errors):
         super().__init__(errors)
         self.error = "The request parameter validation returned an error: {errors}"
 
     def __str__(self):
         return self.error
+
 
 class Request:
     """Creates requests to the Netbox API.

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -108,6 +108,26 @@ class ContentError(Exception):
     def __str__(self):
         return self.error
 
+class ParameterValidationError(Exception):
+    """API parameter validation Exception.
+    
+    Raised when filter parameters do not match Netbox OpenAPI specification.
+
+    ## Examples
+
+    ```python
+    try:
+        nb.dcim.devices.filter(field_which_does_not_exist="destined-for-failure")
+    except pynetbox.ParameterValidationError as e:
+        print(e.error)
+    ```
+    """
+    def __init__(self, errors):
+        super().__init__(errors)
+        self.error = "The request parameter validation returned an error: {errors}"
+
+    def __str__(self):
+        return self.error
 
 class Request:
     """Creates requests to the Netbox API.

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -5,15 +5,21 @@ from tests.util import openapi_mock
 from pynetbox.core.endpoint import Endpoint
 from pynetbox import ParameterValidationError
 
+
 def app_str(self):
     return self.name
+
 
 class EndPointTestCase(unittest.TestCase):
     def test_filter(self):
         with patch(
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
-            api = Mock(base_url="http://localhost:8000/api", strict_filters=False, openapi=openapi_mock)
+            api = Mock(
+                base_url="http://localhost:8000/api",
+                strict_filters=False,
+                openapi=openapi_mock,
+            )
             app = Mock(name="test")
             mock.return_value = [{"id": 123}, {"id": 321}]
             test_obj = Endpoint(api, app, "test")
@@ -24,9 +30,13 @@ class EndPointTestCase(unittest.TestCase):
         with patch(
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
-            api = Mock(base_url="http://localhost:8000/api", strict_filters=True, openapi=openapi_mock)
+            api = Mock(
+                base_url="http://localhost:8000/api",
+                strict_filters=True,
+                openapi=openapi_mock,
+            )
             app = Mock(name="test")
-            app.name="test"
+            app.name = "test"
             mock.return_value = [{"id": 123}, {"id": 321}]
             test_obj = Endpoint(api, app, "test")
             test = test_obj.filter(test="test")
@@ -36,20 +46,28 @@ class EndPointTestCase(unittest.TestCase):
         with patch(
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
-            api = Mock(base_url="http://localhost:8000/api", strict_filters=True, openapi=openapi_mock)
+            api = Mock(
+                base_url="http://localhost:8000/api",
+                strict_filters=True,
+                openapi=openapi_mock,
+            )
             app = Mock(name="test")
-            app.name="test"
+            app.name = "test"
             test_obj = Endpoint(api, app, "test")
             with self.assertRaises(ParameterValidationError):
                 test_obj.filter(very_invalid_kwarg="test")
-            
+
     def test_filter_strict_per_request_disable_invalid_kwarg(self):
         with patch(
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
-            api = Mock(base_url="http://localhost:8000/api", strict_filters=True, openapi=openapi_mock)
+            api = Mock(
+                base_url="http://localhost:8000/api",
+                strict_filters=True,
+                openapi=openapi_mock,
+            )
             app = Mock(name="test")
-            app.name="test"
+            app.name = "test"
             test_obj = Endpoint(api, app, "test")
             test_obj.filter(very_invalid_kwarg="test", strict_filters=False)
 
@@ -59,7 +77,7 @@ class EndPointTestCase(unittest.TestCase):
         ) as mock:
             api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
             app = Mock(name="test")
-            app.name="test"
+            app.name = "test"
             test_obj = Endpoint(api, app, "test")
             with self.assertRaises(ParameterValidationError):
                 test_obj.filter(very_invalid_kwarg="test", strict_filters=True)
@@ -72,7 +90,11 @@ class EndPointTestCase(unittest.TestCase):
             test_obj.filter(offset=1)
 
     def test_filter_replace_none_with_null(self):
-        api = Mock(base_url="http://localhost:8000/api", strict_filters=False, openapi=openapi_mock)
+        api = Mock(
+            base_url="http://localhost:8000/api",
+            strict_filters=False,
+            openapi=openapi_mock,
+        )
         app = Mock(name="test")
         test_obj = Endpoint(api, app, "test")
         test = test_obj.filter(name=None, id=0)
@@ -166,7 +188,11 @@ class EndPointTestCase(unittest.TestCase):
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
             mock.return_value = [{"id": 123}]
-            api = Mock(base_url="http://localhost:8000/api", strict_filters=False, openapi=openapi_mock)
+            api = Mock(
+                base_url="http://localhost:8000/api",
+                strict_filters=False,
+                openapi=openapi_mock,
+            )
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             test = test_obj.get(name="test")
@@ -229,7 +255,11 @@ class EndPointTestCase(unittest.TestCase):
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
             mock.return_value = [{"id": 123}, {"id": 321}]
-            api = Mock(base_url="http://localhost:8000/api", strict_filters=False, openapi=openapi_mock)
+            api = Mock(
+                base_url="http://localhost:8000/api",
+                strict_filters=False,
+                openapi=openapi_mock,
+            )
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             with self.assertRaises(ValueError) as _:
@@ -240,7 +270,11 @@ class EndPointTestCase(unittest.TestCase):
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
             mock.return_value = []
-            api = Mock(base_url="http://localhost:8000/api", strict_filters=False, openapi=openapi_mock)
+            api = Mock(
+                base_url="http://localhost:8000/api",
+                strict_filters=False,
+                openapi=openapi_mock,
+            )
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             test = test_obj.get(name="test")

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -13,7 +13,7 @@ class EndPointTestCase(unittest.TestCase):
         with patch(
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
-            api = Mock(base_url="http://localhost:8000/api", strict_filters=False)
+            api = Mock(base_url="http://localhost:8000/api", strict_filters=False, openapi=openapi_mock)
             app = Mock(name="test")
             mock.return_value = [{"id": 123}, {"id": 321}]
             test_obj = Endpoint(api, app, "test")
@@ -72,7 +72,7 @@ class EndPointTestCase(unittest.TestCase):
             test_obj.filter(offset=1)
 
     def test_filter_replace_none_with_null(self):
-        api = Mock(base_url="http://localhost:8000/api", strict_filters=False)
+        api = Mock(base_url="http://localhost:8000/api", strict_filters=False, openapi=openapi_mock)
         app = Mock(name="test")
         test_obj = Endpoint(api, app, "test")
         test = test_obj.filter(name=None, id=0)
@@ -80,7 +80,7 @@ class EndPointTestCase(unittest.TestCase):
         self.assertEqual(test.request.filters, {"name": "null", "id": 0})
 
     def test_all_invalid_pagination_args(self):
-        api = Mock(base_url="http://localhost:8000/api")
+        api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
         app = Mock(name="test")
         test_obj = Endpoint(api, app, "test")
         with self.assertRaises(ValueError) as _:
@@ -88,7 +88,7 @@ class EndPointTestCase(unittest.TestCase):
 
     def test_choices(self):
         with patch("pynetbox.core.query.Request.options", return_value=Mock()) as mock:
-            api = Mock(base_url="http://localhost:8000/api")
+            api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
             app = Mock(name="test")
             mock.return_value = {
                 "actions": {
@@ -110,7 +110,7 @@ class EndPointTestCase(unittest.TestCase):
 
     def test_choices_put(self):
         with patch("pynetbox.core.query.Request.options", return_value=Mock()) as mock:
-            api = Mock(base_url="http://localhost:8000/api")
+            api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
             app = Mock(name="test")
             mock.return_value = {
                 "actions": {
@@ -132,7 +132,7 @@ class EndPointTestCase(unittest.TestCase):
 
     def test_choices_precedence(self):
         with patch("pynetbox.core.query.Request.options", return_value=Mock()) as mock:
-            api = Mock(base_url="http://localhost:8000/api")
+            api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
             app = Mock(name="test")
             mock.return_value = {
                 "actions": {
@@ -166,7 +166,7 @@ class EndPointTestCase(unittest.TestCase):
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
             mock.return_value = [{"id": 123}]
-            api = Mock(base_url="http://localhost:8000/api", strict_filters=False)
+            api = Mock(base_url="http://localhost:8000/api", strict_filters=False, openapi=openapi_mock)
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             test = test_obj.get(name="test")
@@ -178,7 +178,7 @@ class EndPointTestCase(unittest.TestCase):
         ) as mock:
             ids = [1, 3, 5]
             mock.return_value = True
-            api = Mock(base_url="http://localhost:8000/api")
+            api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             test = test_obj.delete(ids)
@@ -193,7 +193,7 @@ class EndPointTestCase(unittest.TestCase):
 
             ids = [1, 3, 5]
             mock.return_value = True
-            api = Mock(base_url="http://localhost:8000/api")
+            api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             objects = [
@@ -216,7 +216,7 @@ class EndPointTestCase(unittest.TestCase):
                     return iter([{"id": i, "name": "dummy" + str(i)} for i in ids])
 
             mock.return_value = True
-            api = Mock(base_url="http://localhost:8000/api")
+            api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             recordset = RecordSet(test_obj, FakeRequest())
@@ -229,7 +229,7 @@ class EndPointTestCase(unittest.TestCase):
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
             mock.return_value = [{"id": 123}, {"id": 321}]
-            api = Mock(base_url="http://localhost:8000/api", strict_filters=False)
+            api = Mock(base_url="http://localhost:8000/api", strict_filters=False, openapi=openapi_mock)
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             with self.assertRaises(ValueError) as _:
@@ -240,7 +240,7 @@ class EndPointTestCase(unittest.TestCase):
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
             mock.return_value = []
-            api = Mock(base_url="http://localhost:8000/api", strict_filters=False)
+            api = Mock(base_url="http://localhost:8000/api", strict_filters=False, openapi=openapi_mock)
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             test = test_obj.get(name="test")
@@ -254,7 +254,7 @@ class EndPointTestCase(unittest.TestCase):
 
             ids = [1, 3, 5]
             mock.return_value = True
-            api = Mock(base_url="http://localhost:8000/api")
+            api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             objects = [
@@ -281,7 +281,7 @@ class EndPointTestCase(unittest.TestCase):
             ids = [1, 3, 5]
             changes = [{"id": i, "name": "puffy" + str(i)} for i in ids]
             mock.return_value = True
-            api = Mock(base_url="http://localhost:8000/api")
+            api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
             app = Mock(name="test")
             mock.return_value = changes
             test_obj = Endpoint(api, app, "test")

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -1,20 +1,49 @@
 import unittest
 from unittest.mock import Mock, patch
+from tests.util import openapi_mock
 
 from pynetbox.core.endpoint import Endpoint
 
+
+def app_str(self):
+    return self.name
 
 class EndPointTestCase(unittest.TestCase):
     def test_filter(self):
         with patch(
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
-            api = Mock(base_url="http://localhost:8000/api")
+            api = Mock(base_url="http://localhost:8000/api", strict_filters=False)
             app = Mock(name="test")
             mock.return_value = [{"id": 123}, {"id": 321}]
             test_obj = Endpoint(api, app, "test")
             test = test_obj.filter(test="test")
             self.assertEqual(len(test), 2)
+
+    def test_filter_strict(self):
+        with patch(
+            "pynetbox.core.query.Request._make_call", return_value=Mock()
+        ) as mock:
+            api = Mock(base_url="http://localhost:8000/api", strict_filters=True, openapi=openapi_mock)
+            app = Mock(name="test")
+            app.name="test"
+            mock.return_value = [{"id": 123}, {"id": 321}]
+            test_obj = Endpoint(api, app, "test")
+            test = test_obj.filter(test="test")
+            self.assertEqual(len(test), 2)
+
+    def test_filter_strict_invalid_kwarg(self):
+        with patch(
+            "pynetbox.core.query.Request._make_call", return_value=Mock()
+        ) as mock:
+            api = Mock(base_url="http://localhost:8000/api", strict_filters=True, openapi=openapi_mock)
+            app = Mock(name="test")
+            app.name="test"
+            mock.return_value = [{"id": 123}, {"id": 321}]
+            test_obj = Endpoint(api, app, "test")
+            with self.assertRaises(RuntimeError):
+                test_obj.filter(sadasdasda="test")
+            
 
     def test_filter_invalid_pagination_args(self):
         api = Mock(base_url="http://localhost:8000/api")
@@ -24,7 +53,7 @@ class EndPointTestCase(unittest.TestCase):
             test_obj.filter(offset=1)
 
     def test_filter_replace_none_with_null(self):
-        api = Mock(base_url="http://localhost:8000/api")
+        api = Mock(base_url="http://localhost:8000/api", strict_filters=False)
         app = Mock(name="test")
         test_obj = Endpoint(api, app, "test")
         test = test_obj.filter(name=None, id=0)
@@ -118,7 +147,7 @@ class EndPointTestCase(unittest.TestCase):
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
             mock.return_value = [{"id": 123}]
-            api = Mock(base_url="http://localhost:8000/api")
+            api = Mock(base_url="http://localhost:8000/api", strict_filters=False)
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             test = test_obj.get(name="test")
@@ -181,7 +210,7 @@ class EndPointTestCase(unittest.TestCase):
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
             mock.return_value = [{"id": 123}, {"id": 321}]
-            api = Mock(base_url="http://localhost:8000/api")
+            api = Mock(base_url="http://localhost:8000/api", strict_filters=False)
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             with self.assertRaises(ValueError) as _:
@@ -192,7 +221,7 @@ class EndPointTestCase(unittest.TestCase):
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
             mock.return_value = []
-            api = Mock(base_url="http://localhost:8000/api")
+            api = Mock(base_url="http://localhost:8000/api", strict_filters=False)
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             test = test_obj.get(name="test")

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -1,13 +1,7 @@
 import unittest
 from unittest.mock import Mock, patch
-from tests.util import openapi_mock
 
 from pynetbox.core.endpoint import Endpoint
-from pynetbox import ParameterValidationError
-
-
-def app_str(self):
-    return self.name
 
 
 class EndPointTestCase(unittest.TestCase):
@@ -15,72 +9,12 @@ class EndPointTestCase(unittest.TestCase):
         with patch(
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
-            api = Mock(
-                base_url="http://localhost:8000/api",
-                strict_filters=False,
-                openapi=openapi_mock,
-            )
+            api = Mock(base_url="http://localhost:8000/api", strict_filters=False)
             app = Mock(name="test")
             mock.return_value = [{"id": 123}, {"id": 321}]
             test_obj = Endpoint(api, app, "test")
             test = test_obj.filter(test="test")
             self.assertEqual(len(test), 2)
-
-    def test_filter_strict(self):
-        with patch(
-            "pynetbox.core.query.Request._make_call", return_value=Mock()
-        ) as mock:
-            api = Mock(
-                base_url="http://localhost:8000/api",
-                strict_filters=True,
-                openapi=openapi_mock,
-            )
-            app = Mock(name="test")
-            app.name = "test"
-            mock.return_value = [{"id": 123}, {"id": 321}]
-            test_obj = Endpoint(api, app, "test")
-            test = test_obj.filter(test="test")
-            self.assertEqual(len(test), 2)
-
-    def test_filter_strict_invalid_kwarg(self):
-        with patch(
-            "pynetbox.core.query.Request._make_call", return_value=Mock()
-        ) as mock:
-            api = Mock(
-                base_url="http://localhost:8000/api",
-                strict_filters=True,
-                openapi=openapi_mock,
-            )
-            app = Mock(name="test")
-            app.name = "test"
-            test_obj = Endpoint(api, app, "test")
-            with self.assertRaises(ParameterValidationError):
-                test_obj.filter(very_invalid_kwarg="test")
-
-    def test_filter_strict_per_request_disable_invalid_kwarg(self):
-        with patch(
-            "pynetbox.core.query.Request._make_call", return_value=Mock()
-        ) as mock:
-            api = Mock(
-                base_url="http://localhost:8000/api",
-                strict_filters=True,
-                openapi=openapi_mock,
-            )
-            app = Mock(name="test")
-            app.name = "test"
-            test_obj = Endpoint(api, app, "test")
-            test_obj.filter(very_invalid_kwarg="test", strict_filters=False)
-
-    def test_filter_strict_per_request_enable_invalid_kwarg(self):
-        with patch(
-            "pynetbox.core.query.Request._make_call", return_value=Mock()
-        ) as mock:
-            api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
-            app = Mock(name="test")
-            app.name = "test"
-            test_obj = Endpoint(api, app, "test")
-            with self.assertRaises(ParameterValidationError):
-                test_obj.filter(very_invalid_kwarg="test", strict_filters=True)
 
     def test_filter_invalid_pagination_args(self):
         api = Mock(base_url="http://localhost:8000/api")
@@ -90,11 +24,7 @@ class EndPointTestCase(unittest.TestCase):
             test_obj.filter(offset=1)
 
     def test_filter_replace_none_with_null(self):
-        api = Mock(
-            base_url="http://localhost:8000/api",
-            strict_filters=False,
-            openapi=openapi_mock,
-        )
+        api = Mock(base_url="http://localhost:8000/api", strict_filters=False)
         app = Mock(name="test")
         test_obj = Endpoint(api, app, "test")
         test = test_obj.filter(name=None, id=0)
@@ -102,7 +32,7 @@ class EndPointTestCase(unittest.TestCase):
         self.assertEqual(test.request.filters, {"name": "null", "id": 0})
 
     def test_all_invalid_pagination_args(self):
-        api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
+        api = Mock(base_url="http://localhost:8000/api")
         app = Mock(name="test")
         test_obj = Endpoint(api, app, "test")
         with self.assertRaises(ValueError) as _:
@@ -110,7 +40,7 @@ class EndPointTestCase(unittest.TestCase):
 
     def test_choices(self):
         with patch("pynetbox.core.query.Request.options", return_value=Mock()) as mock:
-            api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
+            api = Mock(base_url="http://localhost:8000/api")
             app = Mock(name="test")
             mock.return_value = {
                 "actions": {
@@ -132,7 +62,7 @@ class EndPointTestCase(unittest.TestCase):
 
     def test_choices_put(self):
         with patch("pynetbox.core.query.Request.options", return_value=Mock()) as mock:
-            api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
+            api = Mock(base_url="http://localhost:8000/api")
             app = Mock(name="test")
             mock.return_value = {
                 "actions": {
@@ -154,7 +84,7 @@ class EndPointTestCase(unittest.TestCase):
 
     def test_choices_precedence(self):
         with patch("pynetbox.core.query.Request.options", return_value=Mock()) as mock:
-            api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
+            api = Mock(base_url="http://localhost:8000/api")
             app = Mock(name="test")
             mock.return_value = {
                 "actions": {
@@ -188,11 +118,7 @@ class EndPointTestCase(unittest.TestCase):
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
             mock.return_value = [{"id": 123}]
-            api = Mock(
-                base_url="http://localhost:8000/api",
-                strict_filters=False,
-                openapi=openapi_mock,
-            )
+            api = Mock(base_url="http://localhost:8000/api", strict_filters=False)
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             test = test_obj.get(name="test")
@@ -204,7 +130,7 @@ class EndPointTestCase(unittest.TestCase):
         ) as mock:
             ids = [1, 3, 5]
             mock.return_value = True
-            api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
+            api = Mock(base_url="http://localhost:8000/api")
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             test = test_obj.delete(ids)
@@ -219,7 +145,7 @@ class EndPointTestCase(unittest.TestCase):
 
             ids = [1, 3, 5]
             mock.return_value = True
-            api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
+            api = Mock(base_url="http://localhost:8000/api")
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             objects = [
@@ -242,7 +168,7 @@ class EndPointTestCase(unittest.TestCase):
                     return iter([{"id": i, "name": "dummy" + str(i)} for i in ids])
 
             mock.return_value = True
-            api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
+            api = Mock(base_url="http://localhost:8000/api")
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             recordset = RecordSet(test_obj, FakeRequest())
@@ -255,11 +181,7 @@ class EndPointTestCase(unittest.TestCase):
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
             mock.return_value = [{"id": 123}, {"id": 321}]
-            api = Mock(
-                base_url="http://localhost:8000/api",
-                strict_filters=False,
-                openapi=openapi_mock,
-            )
+            api = Mock(base_url="http://localhost:8000/api", strict_filters=False)
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             with self.assertRaises(ValueError) as _:
@@ -270,11 +192,7 @@ class EndPointTestCase(unittest.TestCase):
             "pynetbox.core.query.Request._make_call", return_value=Mock()
         ) as mock:
             mock.return_value = []
-            api = Mock(
-                base_url="http://localhost:8000/api",
-                strict_filters=False,
-                openapi=openapi_mock,
-            )
+            api = Mock(base_url="http://localhost:8000/api", strict_filters=False)
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             test = test_obj.get(name="test")
@@ -288,7 +206,7 @@ class EndPointTestCase(unittest.TestCase):
 
             ids = [1, 3, 5]
             mock.return_value = True
-            api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
+            api = Mock(base_url="http://localhost:8000/api")
             app = Mock(name="test")
             test_obj = Endpoint(api, app, "test")
             objects = [
@@ -315,7 +233,7 @@ class EndPointTestCase(unittest.TestCase):
             ids = [1, 3, 5]
             changes = [{"id": i, "name": "puffy" + str(i)} for i in ids]
             mock.return_value = True
-            api = Mock(base_url="http://localhost:8000/api", openapi=openapi_mock)
+            api = Mock(base_url="http://localhost:8000/api")
             app = Mock(name="test")
             mock.return_value = changes
             test_obj = Endpoint(api, app, "test")

--- a/tests/unit/test_endpoint_strict_filter.py
+++ b/tests/unit/test_endpoint_strict_filter.py
@@ -1,0 +1,69 @@
+import unittest
+from unittest.mock import Mock, patch
+from tests.util import openapi_mock
+
+from pynetbox.core.endpoint import Endpoint
+from pynetbox import ParameterValidationError
+
+
+class StrictFilterTestCase(unittest.TestCase):
+
+    def test_filter_strict_valid_kwargs(self):
+        with patch(
+            "pynetbox.core.query.Request._make_call", return_value=Mock()
+        ) as mock:
+            api = Mock(
+                base_url="http://localhost:8000/api",
+                strict_filters=True,
+                openapi=openapi_mock,
+            )
+            app = Mock(name="test")
+            app.name = "test"
+            test_obj = Endpoint(api, app, "test")
+            test_obj.filter(test="test")
+
+    def test_filter_strict_invalid_kwarg(self):
+        with patch(
+            "pynetbox.core.query.Request._make_call", return_value=Mock()
+        ) as mock:
+            api = Mock(
+                base_url="http://localhost:8000/api",
+                strict_filters=True,
+                openapi=openapi_mock,
+            )
+            app = Mock(name="test")
+            app.name = "test"
+            test_obj = Endpoint(api, app, "test")
+            with self.assertRaises(ParameterValidationError):
+                test_obj.filter(very_invalid_kwarg="test")
+
+    def test_filter_strict_per_request_disable_invalid_kwarg(self):
+        with patch(
+            "pynetbox.core.query.Request._make_call", return_value=Mock()
+        ) as mock:
+            api = Mock(
+                base_url="http://localhost:8000/api",
+                strict_filters=True,  # Enable globally
+                openapi=openapi_mock,
+            )
+            app = Mock(name="test")
+            app.name = "test"
+            test_obj = Endpoint(api, app, "test")
+            # Disable strict_filters only for this specific request
+            test_obj.filter(very_invalid_kwarg="test", strict_filters=False)
+
+    def test_filter_strict_per_request_enable_invalid_kwarg(self):
+        with patch(
+            "pynetbox.core.query.Request._make_call", return_value=Mock()
+        ) as mock:
+            api = Mock(
+                base_url="http://localhost:8000/api",
+                strict_filters=False,  # Disable globally
+                openapi=openapi_mock,
+            )
+            app = Mock(name="test")
+            app.name = "test"
+            test_obj = Endpoint(api, app, "test")
+            with self.assertRaises(ParameterValidationError):
+                # Enable strict_filters only for this specific request
+                test_obj.filter(very_invalid_kwarg="test", strict_filters=True)

--- a/tests/unit/test_endpoint_strict_filter.py
+++ b/tests/unit/test_endpoint_strict_filter.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 from tests.util import openapi_mock
 
 from pynetbox.core.endpoint import Endpoint

--- a/tests/unit/test_endpoint_strict_filter.py
+++ b/tests/unit/test_endpoint_strict_filter.py
@@ -9,61 +9,49 @@ from pynetbox import ParameterValidationError
 class StrictFilterTestCase(unittest.TestCase):
 
     def test_filter_strict_valid_kwargs(self):
-        with patch(
-            "pynetbox.core.query.Request._make_call", return_value=Mock()
-        ) as mock:
-            api = Mock(
-                base_url="http://localhost:8000/api",
-                strict_filters=True,
-                openapi=openapi_mock,
-            )
-            app = Mock(name="test")
-            app.name = "test"
-            test_obj = Endpoint(api, app, "test")
-            test_obj.filter(test="test")
+        api = Mock(
+            base_url="http://localhost:8000/api",
+            strict_filters=True,
+            openapi=openapi_mock,
+        )
+        app = Mock(name="test")
+        app.name = "test"
+        test_obj = Endpoint(api, app, "test")
+        test_obj.filter(test="test")
 
     def test_filter_strict_invalid_kwarg(self):
-        with patch(
-            "pynetbox.core.query.Request._make_call", return_value=Mock()
-        ) as mock:
-            api = Mock(
-                base_url="http://localhost:8000/api",
-                strict_filters=True,
-                openapi=openapi_mock,
-            )
-            app = Mock(name="test")
-            app.name = "test"
-            test_obj = Endpoint(api, app, "test")
-            with self.assertRaises(ParameterValidationError):
-                test_obj.filter(very_invalid_kwarg="test")
+        api = Mock(
+            base_url="http://localhost:8000/api",
+            strict_filters=True,
+            openapi=openapi_mock,
+        )
+        app = Mock(name="test")
+        app.name = "test"
+        test_obj = Endpoint(api, app, "test")
+        with self.assertRaises(ParameterValidationError):
+            test_obj.filter(very_invalid_kwarg="test")
 
     def test_filter_strict_per_request_disable_invalid_kwarg(self):
-        with patch(
-            "pynetbox.core.query.Request._make_call", return_value=Mock()
-        ) as mock:
-            api = Mock(
-                base_url="http://localhost:8000/api",
-                strict_filters=True,  # Enable globally
-                openapi=openapi_mock,
-            )
-            app = Mock(name="test")
-            app.name = "test"
-            test_obj = Endpoint(api, app, "test")
-            # Disable strict_filters only for this specific request
-            test_obj.filter(very_invalid_kwarg="test", strict_filters=False)
+        api = Mock(
+            base_url="http://localhost:8000/api",
+            strict_filters=True,  # Enable globally
+            openapi=openapi_mock,
+        )
+        app = Mock(name="test")
+        app.name = "test"
+        test_obj = Endpoint(api, app, "test")
+        # Disable strict_filters only for this specific request
+        test_obj.filter(very_invalid_kwarg="test", strict_filters=False)
 
     def test_filter_strict_per_request_enable_invalid_kwarg(self):
-        with patch(
-            "pynetbox.core.query.Request._make_call", return_value=Mock()
-        ) as mock:
-            api = Mock(
-                base_url="http://localhost:8000/api",
-                strict_filters=False,  # Disable globally
-                openapi=openapi_mock,
-            )
-            app = Mock(name="test")
-            app.name = "test"
-            test_obj = Endpoint(api, app, "test")
-            with self.assertRaises(ParameterValidationError):
-                # Enable strict_filters only for this specific request
-                test_obj.filter(very_invalid_kwarg="test", strict_filters=True)
+        api = Mock(
+            base_url="http://localhost:8000/api",
+            strict_filters=False,  # Disable globally
+            openapi=openapi_mock,
+        )
+        app = Mock(name="test")
+        app.name = "test"
+        test_obj = Endpoint(api, app, "test")
+        with self.assertRaises(ParameterValidationError):
+            # Enable strict_filters only for this specific request
+            test_obj.filter(very_invalid_kwarg="test", strict_filters=True)

--- a/tests/util.py
+++ b/tests/util.py
@@ -6,7 +6,6 @@ class Response:
         self.status_code = status_code
         self.content = json.dumps(content) if content else self.load_fixture(fixture)
         self.ok = ok
-        self.headers = {"API-Version": "3.1"}
 
     def load_fixture(self, path):
         if not path:

--- a/tests/util.py
+++ b/tests/util.py
@@ -6,7 +6,7 @@ class Response:
         self.status_code = status_code
         self.content = json.dumps(content) if content else self.load_fixture(fixture)
         self.ok = ok
-        self.headers = {"API-Version":'3.1'}
+        self.headers = {"API-Version": "3.1"}
 
     def load_fixture(self, path):
         if not path:
@@ -17,16 +17,16 @@ class Response:
     def json(self):
         return json.loads(self.content)
 
+
 def openapi_mock():
-    """Mock function to simulate Api.openapi()
-    """
+    """Mock function to simulate Api.openapi()"""
     return {
         "paths": {
-            "/api/test/test/" : {
-                "get" : {
-                    "parameters" :[
-                        {"name":"test"},
-                        {"name":"name"},
+            "/api/test/test/": {
+                "get": {
+                    "parameters": [
+                        {"name": "test"},
+                        {"name": "name"},
                     ]
                 },
             },

--- a/tests/util.py
+++ b/tests/util.py
@@ -15,3 +15,19 @@ class Response:
 
     def json(self):
         return json.loads(self.content)
+
+def openapi_mock():
+    """Mock function to simulate Api.openapi()
+    """
+    return {
+        "paths": {
+            "/api/test/test/" : {
+                "get" : {
+                    "parameters" :[
+                        {"name":"test"},
+                        {"name":"name"},
+                    ]
+                },
+            },
+        },
+    }

--- a/tests/util.py
+++ b/tests/util.py
@@ -6,6 +6,7 @@ class Response:
         self.status_code = status_code
         self.content = json.dumps(content) if content else self.load_fixture(fixture)
         self.ok = ok
+        self.headers = {"API-Version":'3.1'}
 
     def load_fixture(self, path):
         if not path:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to pynetbox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #695 

Validation of filter() kwargs is optionnaly done in pynetbox:
* it can be enabled globally with `strict_filters=True` when instanciating the API object
* it can be enabled/disabled per request by setting `strict_filters` on the `filter()` or `get()` methods
* if enabled a `ParameterValidationError` is raised
* if disabled a line is printed in stdout