### PR TITLE
Fixes #698: Add render config to virtualization model

### DIFF
--- a/pynetbox/models/virtualization.py
+++ b/pynetbox/models/virtualization.py
@@ -37,7 +37,7 @@ class VirtualMachines(Record):
 
         :Examples:
 
-        >>> vm = nb.ipam.virtual_machines.get(123)
+        >>> vm = nb.virtualization.virtual_machines.get(123)
         >>> vm.render_config.create()
         """
         return DetailEndpoint(self, "render-config")


### PR DESCRIPTION
feat: add render-config capability to virtual machines

<!--
    Thank you for your interest in contributing to pynetbox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #698

<!--
    Please include a summary of the proposed changes below.
-->

Adds render_config method to the VirtualMachines class in the virtualization model. 

This feature exposes the existing NetBox API /api/virtualization/virtual-machines/{id}/render-config/ endpoint in pynetbox allowing for the rendering of configurations for virtual machines.

This is functionally equivalent to the render_config method for the Devices class in the dcim model, triggering a configuration render and returning a DetailEndpoint object.
