### PR TITLE
Consider object_types as set in the response

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -23,7 +23,7 @@ from pynetbox.core.query import Request
 from pynetbox.core.util import Hashabledict
 
 # List of fields that are lists but should be treated as sets.
-LIST_AS_SET = ("tags", "tagged_vlans")
+LIST_AS_SET = ("tags", "tagged_vlans", "object_types")
 
 
 def get_return(lookup, return_fields=None):


### PR DESCRIPTION
Fixes: #711

As documented in netbox-community/ansible_modules#1486 I would like to bringe the list_as_set variable in line with the ansible module.

Currently updating the netbox permissions via ansible results in reported changed cause the field object_types is compared as ordered list, not as set.
