### PR TITLE
remove netbox-python from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,3 @@ With Docker installed and running, execute the following command to run the test
 ```python
 pytest
 ```
-
-## Alternative Library
-
-> **Note:** For those interested in a different approach, there is an alternative Python API client library available for NetBox called [netbox-python](https://github.com/netbox-community/netbox-python). This library provides a thin Python wrapper over the NetBox API.
-
-[netbox-python](https://github.com/netbox-community/netbox-python) offers a minimalistic interface to interact with NetBox's API. While it may not provide all the features available in pynetbox, it offers a lightweight and straightforward option for interfacing with NetBox.
-
-To explore further details and access the documentation, please visit the [netbox-python](https://github.com/netbox-community/netbox-python).


### PR DESCRIPTION
### Fixes: #719 

netbox-python is now archived, so removing it from the readme.