### PR TITLE
Fixes #718: Add token when getting NetBox version to prevent 403 error

### DIFF
--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -259,9 +259,9 @@ class Request:
         ## Raises
         RequestError if req.ok returns false.
         """
-        headers = {
-            "Content-Type": "application/json",
-        }
+        headers = {"Content-Type": "application/json"}
+        if self.token:
+            headers["authorization"] = "Token {}".format(self.token)
         req = self.http_session.get(
             self.normalize_url(self.base),
             headers=headers,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to pynetbox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #718

<!--
    Please include a summary of the proposed changes below.
-->

`Request.get_version()` now includes the authorization token (if present in the API object) when calling NetBox `/api/`, to get the NetBox API version without causing 403 error in the NetBox reverse proxy and Django logs.
