### PR TITLE
#700 move ObjectChange to core

### DIFF
--- a/pynetbox/core/app.py
+++ b/pynetbox/core/app.py
@@ -18,6 +18,7 @@ from pynetbox.core.endpoint import Endpoint
 from pynetbox.core.query import Request
 from pynetbox.models import (
     circuits,
+    core,
     dcim,
     extras,
     ipam,
@@ -45,12 +46,13 @@ class App:
         self._setmodel()
 
     models = {
-        "dcim": dcim,
-        "ipam": ipam,
         "circuits": circuits,
-        "virtualization": virtualization,
+        "core": core,
+        "dcim": dcim,
         "extras": extras,
+        "ipam": ipam,
         "users": users,
+        "virtualization": virtualization,
         "wireless": wireless,
     }
 

--- a/pynetbox/models/core.py
+++ b/pynetbox/models/core.py
@@ -1,0 +1,34 @@
+"""
+(c) 2017 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from pynetbox.core.response import JsonField, Record
+
+
+class DataSources(Record):
+    pass
+
+
+class Jobs(Record):
+    pass
+
+
+class ObjectChanges(Record):
+    object_data = JsonField
+    postchange_data = JsonField
+    prechange_data = JsonField
+
+    def __str__(self):
+        return self.request_id

--- a/pynetbox/models/extras.py
+++ b/pynetbox/models/extras.py
@@ -19,12 +19,3 @@ from pynetbox.core.response import JsonField, Record
 
 class ConfigContexts(Record):
     data = JsonField
-
-
-class ObjectChanges(Record):
-    object_data = JsonField
-    postchange_data = JsonField
-    prechange_data = JsonField
-
-    def __str__(self):
-        return self.request_id

--- a/pynetbox/models/mapper.py
+++ b/pynetbox/models/mapper.py
@@ -1,4 +1,5 @@
 from .circuits import Circuits, CircuitTerminations
+from .core import DataSources, Jobs, ObjectChanges
 from .dcim import (
     Cables,
     ConsolePorts,
@@ -23,6 +24,9 @@ from .wireless import WirelessLans
 CONTENT_TYPE_MAPPER = {
     "circuits.circuit": Circuits,
     "circuits.circuittermination": CircuitTerminations,
+    "core.datasource": DataSources,
+    "core.job": Jobs,
+    "core.objectchange": ObjectChanges,
     "dcim.cable": Cables,
     "dcim.cablepath": None,
     "dcim.cabletermination": Termination,
@@ -72,7 +76,6 @@ CONTENT_TYPE_MAPPER = {
     "extras.imageattachment": None,
     "extras.jobresult": None,
     "extras.journalentry": None,
-    "extras.objectchange": None,
     "extras.report": None,
     "extras.script": None,
     "extras.tag": None,


### PR DESCRIPTION
### Fixes: #700 

Moves ObjectChange to core. Script to test (update the token to run):

```
import pynetbox
import json

nb = pynetbox.api(
    "http://127.0.0.1:8000/",
    token="106cb162cafaf9d3de62eef949b53116289c06a9",
    threading=True,
)


# Test ObjectChanges from core app
print("Fetching object changes...")
object_changes = nb.core.object_changes.all()

count = 0
for oc in object_changes:
    if count >= 5:  # Limit to first 5 for readability
        break
    count += 1
    print(f"\n--- Object Change: {oc} ---")
    print(f"ID: {oc.id}")
    print(f"Request ID: {oc.request_id}")
    print(f"Action: {oc.action}")
    print(f"Changed Object Type: {oc.changed_object_type}")
    print(f"Changed Object ID: {oc.changed_object_id}")
    print(f"User: {oc.user}")
    print(f"Time: {oc.time}")

    # Display JSON fields
    if oc.prechange_data:
        print("\nPre-change Data:")
        print(json.dumps(oc.prechange_data, indent=2))

    if oc.postchange_data:
        print("\nPost-change Data:")
        print(json.dumps(oc.postchange_data, indent=2))

print(f"\n\nDisplayed first {count} object changes")
```