### PR TITLE
v7.6.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -11,7 +11,7 @@ body:
     attributes:
       label: pynetbox version
       description: What version of pynetbox are you currently running?
-      placeholder: v7.5.0
+      placeholder: v7.6.0
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Each pyNetBox Version listed below has been tested with its corresponding NetBox
 
 | NetBox Version | Plugin Version |
 |:--------------:|:--------------:|
+|      4.5       |     7.6.0      |
+|      4.4       |     7.5.0      |
 |      4.3       |     7.5.0      |
 |      4.2       |     7.5.0      |
 |      4.1       |     7.5.0      |

--- a/pynetbox/__init__.py
+++ b/pynetbox/__init__.py
@@ -6,7 +6,7 @@ from pynetbox.core.query import (
     ParameterValidationError,
 )
 
-__version__ = "7.5.0"
+__version__ = "7.6.0"
 
 # Lowercase alias for backward compatibility
 api = Api


### PR DESCRIPTION
Release v7.6.0

## Breaking Changes

* [#700](https://github.com/netbox-community/pynetbox/issues/700) - Moved ObjectChange to core for NetBox 4.1.0 compatibility 

## New Features

* [#728](https://github.com/netbox-community/pynetbox/issues/728) - Added support for v2 Tokens introduced in NetBox 4.5.0

## Enhancements

* [#505](https://github.com/netbox-community/pynetbox/issues/505) - Add SVG support for Rack Elevation endpoint

## Bugfixes

* [#718](https://github.com/netbox-community/pynetbox/issues/718) - Add token when getting NetBox version to prevent 403 error

**Full Changelog**: https://github.com/netbox-community/pynetbox/compare/v7.5.0...v7.6.0
