### PR TITLE
use dict in Record.serialize

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 import copy
-from collections import OrderedDict
 from urllib.parse import urlsplit
 
 import pynetbox.core.app
@@ -528,7 +527,7 @@ class Record:
                         all([isinstance(v, str) for v in current_val])
                         or all([isinstance(v, int) for v in current_val])
                     ):
-                        current_val = list(OrderedDict.fromkeys(current_val))
+                        current_val = list(dict.fromkeys(current_val))
                 ret[i] = current_val
 
         return ret


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to pynetbox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #726 

<!--
    Please include a summary of the proposed changes below.
-->
Since 3.7, [`dict` preserve key insertion-order](https://docs.python.org/3/whatsnew/3.7.html#what-s-new-in-python-3-7).

c7132d0 got introduced after the release of Python 3.7; this assures us there won't be any regression.

Use it instead of `OrderedDict`.

cc @arthanson 