### PR TITLE
762 netbox46

### DIFF
--- a/pynetbox/models/dcim.py
+++ b/pynetbox/models/dcim.py
@@ -84,6 +84,7 @@ class Devices(Record):
     primary_ip = IpAddresses
     primary_ip4 = IpAddresses
     primary_ip6 = IpAddresses
+    oob_ip = IpAddresses
     local_context_data = JsonField
     config_context = JsonField
 

--- a/pynetbox/models/mapper.py
+++ b/pynetbox/models/mapper.py
@@ -23,7 +23,7 @@ from .dcim import (
     VirtualChassis,
 )
 from .ipam import Aggregates, IpAddresses, Prefixes, VlanGroups, Vlans
-from .virtualization import VirtualMachines
+from .virtualization import VirtualMachineTypes, VirtualMachines
 from .wireless import WirelessLans
 
 CONTENT_TYPE_MAPPER = {
@@ -35,6 +35,7 @@ CONTENT_TYPE_MAPPER = {
     "core.job": Jobs,
     "core.objectchange": ObjectChanges,
     "dcim.cable": Cables,
+    "dcim.cablebundle": None,
     "dcim.cablepath": None,
     "dcim.cabletermination": Termination,
     "dcim.consoleport": ConsolePorts,
@@ -67,6 +68,7 @@ CONTENT_TYPE_MAPPER = {
     "dcim.powerport": PowerPorts,
     "dcim.powerporttemplate": None,
     "dcim.rack": Racks,
+    "dcim.rackgroup": None,
     "dcim.rackreservation": RackReservations,
     "dcim.rackrole": None,
     "dcim.rearport": RearPorts,
@@ -116,6 +118,7 @@ CONTENT_TYPE_MAPPER = {
     "virtualization.clustertype": None,
     "virtualization.interface": None,
     "virtualization.virtualmachine": VirtualMachines,
+    "virtualization.virtualmachinetype": VirtualMachineTypes,
     "wireless.WirelessLAN": WirelessLans,
     "wireless.WirelessLANGroup": None,
     "wireless.wirelesslink": None,

--- a/pynetbox/models/virtualization.py
+++ b/pynetbox/models/virtualization.py
@@ -16,14 +16,21 @@ limitations under the License.
 
 from pynetbox.core.endpoint import DetailEndpoint
 from pynetbox.core.response import JsonField, Record
+from pynetbox.models.dcim import Devices
 from pynetbox.models.ipam import IpAddresses
 
 
+class VirtualMachineTypes(Record):
+    pass
+
+
 class VirtualMachines(Record):
+    device = Devices
     primary_ip = IpAddresses
     primary_ip4 = IpAddresses
     primary_ip6 = IpAddresses
     config_context = JsonField
+    virtual_machine_type = VirtualMachineTypes
 
     @property
     def render_config(self):

--- a/tests/fixtures/dcim/device.json
+++ b/tests/fixtures/dcim/device.json
@@ -64,6 +64,12 @@
         "address": "10.0.255.1/32"
     },
     "primary_ip6": null,
+    "oob_ip": {
+        "id": 5,
+        "url": "http://localhost:8000/api/ipam/ip-addresses/5/",
+        "family": 4,
+        "address": "192.0.2.1/32"
+    },
     "comments": "",
     "local_context_data": {
         "testing": "test"

--- a/tests/fixtures/virtualization/virtual_machine.json
+++ b/tests/fixtures/virtualization/virtual_machine.json
@@ -5,10 +5,17 @@
         "value": 1,
         "label": "Active"
     },
-    "cluster": {
+    "cluster": null,
+    "device": {
         "id": 1,
-        "url": "http://localhost:8000/api/virtualization/clusters/1/",
-        "name": "vm-test-cluster"
+        "url": "http://localhost:8000/api/dcim/devices/1/",
+        "name": "test-device"
+    },
+    "virtual_machine_type": {
+        "id": 1,
+        "url": "http://localhost:8000/api/virtualization/virtual-machine-types/1/",
+        "name": "Standard",
+        "slug": "standard"
     },
     "role": null,
     "tenant": null,

--- a/tests/fixtures/virtualization/virtual_machine_type.json
+++ b/tests/fixtures/virtualization/virtual_machine_type.json
@@ -1,0 +1,6 @@
+{
+    "id": 1,
+    "url": "http://localhost:8000/api/virtualization/virtual-machine-types/1/",
+    "name": "Standard",
+    "slug": "standard"
+}

--- a/tests/fixtures/virtualization/virtual_machine_types.json
+++ b/tests/fixtures/virtualization/virtual_machine_types.json
@@ -1,0 +1,13 @@
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": 1,
+            "url": "http://localhost:8000/api/virtualization/virtual-machine-types/1/",
+            "name": "Standard",
+            "slug": "standard"
+        }
+    ]
+}

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -2,8 +2,7 @@ import unittest
 from unittest.mock import patch
 
 import pynetbox
-from pynetbox.models.dcim import Devices
-from pynetbox.models.virtualization import VirtualMachineTypes
+from pynetbox.models.ipam import IpAddresses
 
 from .util import Response
 
@@ -11,7 +10,7 @@ api = pynetbox.api(
     "http://localhost:8000",
 )
 
-nb = api.virtualization
+nb = api.dcim
 
 HEADERS = {"accept": "application/json"}
 
@@ -20,7 +19,7 @@ class Generic:
     class Tests(unittest.TestCase):
         name = ""
         ret = pynetbox.core.response.Record
-        app = "virtualization"
+        app = "dcim"
 
         def test_get_all(self):
             with patch(
@@ -76,43 +75,14 @@ class Generic:
                 )
 
 
-class ClusterTypesTestCase(Generic.Tests):
-    name = "cluster_types"
-
-
-class ClusterGroupsTestCase(Generic.Tests):
-    name = "cluster_groups"
-
-
-class ClustersTestCase(Generic.Tests):
-    name = "clusters"
-
-
-class VirtualMachinesTestCase(Generic.Tests):
-    name = "virtual_machines"
+class DevicesTestCase(Generic.Tests):
+    name = "devices"
 
     @patch(
         "requests.sessions.Session.get",
-        return_value=Response(fixture="virtualization/virtual_machine.json"),
+        return_value=Response(fixture="dcim/device.json"),
     )
-    def test_device_attr(self, _):
-        vm = nb.virtual_machines.get(1)
-        self.assertIsInstance(vm.device, Devices)
-        self.assertEqual(vm.device.name, "test-device")
-
-    @patch(
-        "requests.sessions.Session.get",
-        return_value=Response(fixture="virtualization/virtual_machine.json"),
-    )
-    def test_virtual_machine_type_attr(self, _):
-        vm = nb.virtual_machines.get(1)
-        self.assertIsInstance(vm.virtual_machine_type, VirtualMachineTypes)
-        self.assertEqual(vm.virtual_machine_type.name, "Standard")
-
-
-class VirtualMachineTypesTestCase(Generic.Tests):
-    name = "virtual_machine_types"
-
-
-class InterfacesTestCase(Generic.Tests):
-    name = "interfaces"
+    def test_oob_ip_attr(self, _):
+        device = nb.devices.get(1)
+        self.assertIsInstance(device.oob_ip, IpAddresses)
+        self.assertEqual(str(device.oob_ip), "192.0.2.1/32")

--- a/tests/unit/test_mapper.py
+++ b/tests/unit/test_mapper.py
@@ -1,0 +1,18 @@
+import unittest
+
+from pynetbox.models.mapper import CONTENT_TYPE_MAPPER
+from pynetbox.models.virtualization import VirtualMachineTypes
+
+
+class ContentTypeMapperTestCase(unittest.TestCase):
+    def test_cable_bundle_registered(self):
+        self.assertIn("dcim.cablebundle", CONTENT_TYPE_MAPPER)
+
+    def test_rack_group_registered(self):
+        self.assertIn("dcim.rackgroup", CONTENT_TYPE_MAPPER)
+
+    def test_virtual_machine_type_registered(self):
+        self.assertIn("virtualization.virtualmachinetype", CONTENT_TYPE_MAPPER)
+        self.assertIs(
+            CONTENT_TYPE_MAPPER["virtualization.virtualmachinetype"], VirtualMachineTypes
+        )


### PR DESCRIPTION
### Fixes: #762 

Add support for NetBox 4.6 API changes

- Add VirtualMachineTypes Record class and register it in the content type mapper (virtualization.virtualmachinetype)
- Add virtual_machine_type = VirtualMachineTypes typed attribute to VirtualMachines, enabling proper deserialization of the new VM categorization field
- Add device = Devices typed attribute to VirtualMachines, supporting VMs assigned directly to a device without a cluster
- Add oob_ip = IpAddresses typed attribute to Devices so out-of-band IP addresses deserialize consistently with primary_ip4/primary_ip6
- Register dcim.cablebundle and dcim.rackgroup in the content type mapper for the two new DCIM models

Script that checks the new APIs

```
#!/usr/bin/env python3
"""
Manual tests for NetBox 4.6 API additions in pynetbox.

Tests:
  - VirtualMachineType CRUD and attribute deserialization
  - VM assigned directly to a device (no cluster) via vm.device
  - vm.virtual_machine_type typed attribute
  - device.oob_ip typed attribute
  - CableBundle and RackGroup endpoints accessible

Requires NetBox 4.6+. Creates and cleans up its own test objects.
"""

import os
import sys

sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

import pynetbox
from pynetbox.models.dcim import Devices
from pynetbox.models.ipam import IpAddresses
from pynetbox.models.virtualization import VirtualMachineTypes

NETBOX_URL = "http://localhost:8000"
NETBOX_TOKEN = "nbt_A2BR9sQCBWv9.xxx"

PREFIX = "pynetbox-test-46"

PASS = "✓"
FAIL = "✗"
SKIP = "⊘"

results = {"passed": 0, "failed": 0, "skipped": 0}


def ok(msg):
    results["passed"] += 1
    print(f"  {PASS} {msg}")


def fail(msg, exc=None):
    results["failed"] += 1
    print(f"  {FAIL} {msg}")
    if exc:
        print(f"      {type(exc).__name__}: {exc}")


def skip(msg):
    results["skipped"] += 1
    print(f"  {SKIP} {msg}")


def section(title):
    print(f"\n{'='*60}")
    print(f"  {title}")
    print(f"{'='*60}")


# ---------------------------------------------------------------------------
# Setup helpers
# ---------------------------------------------------------------------------

def get_or_create_site(nb):
    existing = nb.dcim.sites.filter(name=f"{PREFIX}-site")
    existing = list(existing)
    if existing:
        return existing[0]
    return nb.dcim.sites.create(name=f"{PREFIX}-site", slug=f"{PREFIX}-site")


def get_or_create_manufacturer(nb):
    existing = list(nb.dcim.manufacturers.filter(name=f"{PREFIX}-mfr"))
    if existing:
        return existing[0]
    return nb.dcim.manufacturers.create(name=f"{PREFIX}-mfr", slug=f"{PREFIX}-mfr")


def get_or_create_device_type(nb, manufacturer):
    existing = list(nb.dcim.device_types.filter(model=f"{PREFIX}-dtype"))
    if existing:
        return existing[0]
    return nb.dcim.device_types.create(
        model=f"{PREFIX}-dtype",
        slug=f"{PREFIX}-dtype",
        manufacturer=manufacturer.id,
    )


def get_or_create_device_role(nb):
    existing = list(nb.dcim.device_roles.filter(name=f"{PREFIX}-role"))
    if existing:
        return existing[0]
    return nb.dcim.device_roles.create(name=f"{PREFIX}-role", slug=f"{PREFIX}-role")


def get_or_create_device(nb, site, device_type, role):
    existing = list(nb.dcim.devices.filter(name=f"{PREFIX}-device"))
    if existing:
        return existing[0]
    return nb.dcim.devices.create(
        name=f"{PREFIX}-device",
        site=site.id,
        device_type=device_type.id,
        role=role.id,
    )


def get_or_create_mgmt_interface(nb, device):
    existing = list(nb.dcim.interfaces.filter(device_id=device.id, name=f"{PREFIX}-mgmt"))
    if existing:
        return existing[0]
    return nb.dcim.interfaces.create(
        device=device.id,
        name=f"{PREFIX}-mgmt",
        type="1000base-t",
    )


def get_or_create_ip(nb, interface):
    existing = list(nb.ipam.ip_addresses.filter(address="198.51.100.99/32"))
    if existing:
        ip = existing[0]
        if not ip.assigned_object_id:
            ip.assigned_object_type = "dcim.interface"
            ip.assigned_object_id = interface.id
            ip.save()
        return ip
    return nb.ipam.ip_addresses.create(
        address="198.51.100.99/32",
        assigned_object_type="dcim.interface",
        assigned_object_id=interface.id,
    )


# ---------------------------------------------------------------------------
# Cleanup
# ---------------------------------------------------------------------------

def cleanup(nb):
    section("Cleanup")

    for vm in nb.virtualization.virtual_machines.filter(name=f"{PREFIX}-vm"):
        vm.delete()
        print(f"  Deleted VM: {vm.name}")

    for vmt in nb.virtualization.virtual_machine_types.filter(name=f"{PREFIX}-vmt"):
        vmt.delete()
        print(f"  Deleted VirtualMachineType: {vmt.name}")

    for iface in nb.dcim.interfaces.filter(name=f"{PREFIX}-mgmt"):
        iface.delete()
        print(f"  Deleted Interface: {iface.name}")

    for device in nb.dcim.devices.filter(name=f"{PREFIX}-device"):
        device.delete()
        print(f"  Deleted device: {device.name}")

    for dt in nb.dcim.device_types.filter(model=f"{PREFIX}-dtype"):
        dt.delete()
        print(f"  Deleted DeviceType: {dt.model}")

    for role in nb.dcim.device_roles.filter(name=f"{PREFIX}-role"):
        role.delete()
        print(f"  Deleted DeviceRole: {role.name}")

    for mfr in nb.dcim.manufacturers.filter(name=f"{PREFIX}-mfr"):
        mfr.delete()
        print(f"  Deleted Manufacturer: {mfr.name}")

    for site in nb.dcim.sites.filter(name=f"{PREFIX}-site"):
        site.delete()
        print(f"  Deleted Site: {site.name}")

    for ip in nb.ipam.ip_addresses.filter(address="198.51.100.99/32"):
        ip.delete()
        print(f"  Deleted IP: {ip.address}")

    print("  Done.")


# ---------------------------------------------------------------------------
# Tests
# ---------------------------------------------------------------------------

def test_virtual_machine_type(nb):
    section("VirtualMachineType (new in 4.6)")

    try:
        vmt = nb.virtualization.virtual_machine_types.create(
            name=f"{PREFIX}-vmt",
            slug=f"{PREFIX}-vmt",
        )
        ok(f"Created VirtualMachineType: {vmt.name} (id={vmt.id})")
    except Exception as e:
        fail("Failed to create VirtualMachineType — is this NetBox 4.6+?", e)
        return None

    try:
        fetched = nb.virtualization.virtual_machine_types.get(vmt.id)
        assert fetched.name == vmt.name
        ok(f"Fetched VirtualMachineType by id: {fetched.name}")
    except Exception as e:
        fail("Failed to fetch VirtualMachineType by id", e)

    try:
        listed = list(nb.virtualization.virtual_machine_types.filter(name=f"{PREFIX}-vmt"))
        assert len(listed) == 1
        assert isinstance(listed[0], VirtualMachineTypes)
        ok(f"filter() returns VirtualMachineTypes instance: {listed[0].name}")
    except Exception as e:
        fail("filter() did not return VirtualMachineTypes instances", e)

    return vmt


def test_vm_with_device_and_type(nb, device, vmt):
    section("VirtualMachine.device and VirtualMachine.virtual_machine_type (new in 4.6)")

    try:
        vm = nb.virtualization.virtual_machines.create(
            name=f"{PREFIX}-vm",
            status="active",
            device=device.id,
            virtual_machine_type=vmt.id if vmt else None,
        )
        ok(f"Created VM assigned to device (no cluster): {vm.name} (id={vm.id})")
    except Exception as e:
        fail("Failed to create VM assigned directly to device", e)
        return

    try:
        vm = nb.virtualization.virtual_machines.get(vm.id)
        assert isinstance(vm.device, Devices), f"Expected Devices, got {type(vm.device)}"
        assert vm.device.id == device.id
        ok(f"vm.device is Devices instance: {vm.device.name}")
    except Exception as e:
        fail("vm.device is not a Devices instance", e)

    if vmt:
        try:
            assert isinstance(vm.virtual_machine_type, VirtualMachineTypes), (
                f"Expected VirtualMachineTypes, got {type(vm.virtual_machine_type)}"
            )
            assert vm.virtual_machine_type.id == vmt.id
            ok(f"vm.virtual_machine_type is VirtualMachineTypes instance: {vm.virtual_machine_type.name}")
        except Exception as e:
            fail("vm.virtual_machine_type is not a VirtualMachineTypes instance", e)
    else:
        skip("Skipping virtual_machine_type check (VirtualMachineType creation failed)")


def test_device_oob_ip(nb, device, ip):
    section("Device.oob_ip typed attribute (new in 4.6)")

    try:
        device.oob_ip = ip.id
        device.save()
        ok(f"Set oob_ip on device to {ip.address}")
    except Exception as e:
        fail("Failed to set oob_ip on device", e)
        return

    try:
        refreshed = nb.dcim.devices.get(device.id)
        assert isinstance(refreshed.oob_ip, IpAddresses), (
            f"Expected IpAddresses, got {type(refreshed.oob_ip)}"
        )
        assert str(refreshed.oob_ip) == ip.address
        ok(f"device.oob_ip is IpAddresses instance: {refreshed.oob_ip}")
    except Exception as e:
        fail("device.oob_ip is not an IpAddresses instance", e)


def test_cablebundle_endpoint(nb):
    section("CableBundle endpoint (new in 4.6)")

    try:
        bundles = list(nb.dcim.cable_bundles.all())
        ok(f"nb.dcim.cable_bundles.all() succeeded ({len(bundles)} bundles)")
    except Exception as e:
        fail("nb.dcim.cable_bundles.all() failed — is this NetBox 4.6+?", e)


def test_rackgroup_endpoint(nb):
    section("RackGroup endpoint (new in 4.6)")

    try:
        groups = list(nb.dcim.rack_groups.all())
        ok(f"nb.dcim.rack_groups.all() succeeded ({len(groups)} groups)")
    except Exception as e:
        fail("nb.dcim.rack_groups.all() failed — is this NetBox 4.6+?", e)


# ---------------------------------------------------------------------------
# Main
# ---------------------------------------------------------------------------

def main():
    print(f"\npynetbox NetBox 4.6 API Manual Tests")
    print(f"Target: {NETBOX_URL}")

    nb = pynetbox.api(NETBOX_URL, token=NETBOX_TOKEN)
    print(f"NetBox version: {nb.version}\n")

    cleanup(nb)

    print("\nSetting up prerequisites...")
    site = get_or_create_site(nb)
    manufacturer = get_or_create_manufacturer(nb)
    device_type = get_or_create_device_type(nb, manufacturer)
    role = get_or_create_device_role(nb)
    device = get_or_create_device(nb, site, device_type, role)
    interface = get_or_create_mgmt_interface(nb, device)
    ip = get_or_create_ip(nb, interface)
    print(f"  Device: {device.name} (id={device.id})")
    print(f"  Interface: {interface.name} (id={interface.id})")
    print(f"  OOB IP: {ip.address} (id={ip.id})")

    vmt = test_virtual_machine_type(nb)
    test_vm_with_device_and_type(nb, device, vmt)
    test_device_oob_ip(nb, device, ip)
    test_cablebundle_endpoint(nb)
    test_rackgroup_endpoint(nb)

    cleanup(nb)

    section("Summary")
    total = results["passed"] + results["failed"] + results["skipped"]
    print(f"  {PASS} Passed:  {results['passed']}/{total}")
    if results["skipped"]:
        print(f"  {SKIP} Skipped: {results['skipped']}/{total}")
    if results["failed"]:
        print(f"  {FAIL} Failed:  {results['failed']}/{total}")
        return 1
    print()
    return 0


if __name__ == "__main__":
    sys.exit(main())
```