### PR TITLE
v7.7.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -11,7 +11,7 @@ body:
     attributes:
       label: pynetbox version
       description: What version of pynetbox are you currently running?
-      placeholder: v7.6.1
+      placeholder: v7.7.0
     validations:
       required: true
   - type: input

--- a/.github/workflows/py3.yml
+++ b/.github/workflows/py3.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.12", "3.13", "3.14"]
-        netbox: ["4.4", "4.5", "4.6"]
+        netbox: ["4.3", "4.4", "4.5"]
 
     steps:
       - name: Checkout pynetbox

--- a/.github/workflows/py3.yml
+++ b/.github/workflows/py3.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.12", "3.13", "3.14"]
-        netbox: ["4.3", "4.4", "4.5"]
+        netbox: ["4.4", "4.5", "4.6"]
 
     steps:
       - name: Checkout pynetbox

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Each pyNetBox Version listed below has been tested with its corresponding NetBox
 
 | NetBox Version | Plugin Version |
 |:--------------:|:--------------:|
+|      4.6       |     7.7.0      |
 |      4.5       |     7.6.1      |
 |      4.5       |     7.6.0      |
 |      4.4       |     7.5.0      |

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,19 @@
 # Release Notes
 
+## Version 7.7.0 (May 5, 2026)
+
+#### New Features
+- [#762](https://github.com/netbox-community/pynetbox/issues/762) - Support NetBox 4.6: add `VirtualMachineTypes` model, `virtual_machine_type` and `device` typed attributes on `VirtualMachines`, `oob_ip` typed attribute on `Devices`, and `dcim.cablebundle` / `dcim.rackgroup` content type mappings
+
+#### Bug Fixes
+- [#756](https://github.com/netbox-community/pynetbox/issues/756) - Use v2 token auth value in `create_token` (NetBox 4.5+)
+- [#708](https://github.com/netbox-community/pynetbox/issues/708) - `Record.serialize()` now includes new properties added by the user
+
+#### Compatibility
+- Supports NetBox 4.6
+
+---
+
 ## Version 7.6.1 (January 28, 2026)
 
 #### Enhancements

--- a/pynetbox/__init__.py
+++ b/pynetbox/__init__.py
@@ -6,7 +6,7 @@ from pynetbox.core.query import (
     ParameterValidationError,
 )
 
-__version__ = "7.6.1"
+__version__ = "7.7.0"
 
 # Lowercase alias for backward compatibility
 api = Api


### PR DESCRIPTION
v7.7.0 changes

### New Features
- [#762](https://github.com/netbox-community/pynetbox/issues/762) - Support NetBox 4.6: add `VirtualMachineTypes` model, `virtual_machine_type` and `device` typed attributes on `VirtualMachines`, `oob_ip` typed attribute on `Devices`, and `dcim.cablebundle` / `dcim.rackgroup` content type mappings

### Bug Fixes
- [#756](https://github.com/netbox-community/pynetbox/issues/756) - Use v2 token auth value in `create_token` (NetBox 4.5+)
- [#708](https://github.com/netbox-community/pynetbox/issues/708) - `Record.serialize()` now includes new properties added by the user

### Compatibility
- Supports NetBox 4.6