### PR TITLE
#701 - fix filtering for custom fields

### DIFF
--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -118,9 +118,13 @@ class Endpoint:
                 f"Error while parsing Netbox OpenAPI specification: {exc}"
             )
 
-        # Validate all parameters
+        # Validate all parameters. Custom field filters (cf_<fieldname>, plus
+        # lookup expressions like cf_<fieldname>__gt) are per-instance dynamic
+        # and not listed in the OpenAPI spec, so they are skipped here.
         validation_errors = []
         for p in parameters:
+            if p.startswith("cf_"):
+                continue
             if p not in allowed_parameters:
                 validation_errors.append(
                     f"'{p}' is not allowed as parameter on path '{openapi_definition_path}'."

--- a/tests/unit/test_endpoint_strict_filter.py
+++ b/tests/unit/test_endpoint_strict_filter.py
@@ -55,3 +55,18 @@ class StrictFilterTestCase(unittest.TestCase):
         with self.assertRaises(ParameterValidationError):
             # Enable strict_filters only for this specific request
             test_obj.filter(very_invalid_kwarg="test", strict_filters=True)
+
+    def test_filter_strict_allows_custom_field_kwargs(self):
+        # NetBox custom field filters (cf_<fieldname>) are not enumerated in
+        # the OpenAPI spec but are valid query parameters. Strict validation
+        # must let them through.
+        api = Mock(
+            base_url="http://localhost:8000/api",
+            strict_filters=True,
+            openapi=openapi_mock,
+        )
+        app = Mock(name="test")
+        app.name = "test"
+        test_obj = Endpoint(api, app, "test")
+        test_obj.filter(cf_CRM_ID="121121")
+        test_obj.filter(cf_my_field__gt=10)


### PR DESCRIPTION
### Fixes: #701

nb.tenancy.tenants.filter(cf_crm_id="121121") raised ParameterValidationError under strict_filters=True. NetBox accepts cf_<fieldname> filters but doesn't list them in its OpenAPI spec (they're per-instance).

**Fix:** skip cf_* params in Endpoint._validate_openapi_parameters. Covers lookup variants (cf_field__gt, etc.). Invalid kwargs still rejected.

**Tests:** new unit test in test_endpoint_strict_filter.py; full suite + ruff pass; verified end-to-end against NetBox 4.6.

<details>
<summary>pynetbox test script</summary>

```python
#!/usr/bin/env python3
"""Verify the fix for issue #701.

Reproduces the reported scenario: filter a tenant by a custom field with
``strict_filters=True``. Before the fix this raised ``ParameterValidationError``
because NetBox does not list dynamic ``cf_<fieldname>`` filters in its OpenAPI
spec. After the fix the call succeeds and an invalid kwarg is still rejected.

Usage: python manual_tests/verify_issue_701_fix.py
"""

import os
import sys

sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

import pynetbox
from pynetbox.core.query import ParameterValidationError

NETBOX_URL = os.environ.get("NETBOX_URL", "http://localhost:8000")
NETBOX_TOKEN = "nbt_37c7bkeURqtr.epfWjdxzvSAUJF1QDLofa0brdxMjMk0Rq2XkgkgT"

CF_NAME = "crm_id"
CF_VALUE = "121121"
TENANT_NAME = "pynetbox-issue-701"
TENANT_SLUG = "pynetbox-issue-701"


def get_or_create(endpoint, filter_kwargs, create_kwargs):
    existing = list(endpoint.filter(**filter_kwargs))
    return existing[0] if existing else endpoint.create(**create_kwargs)


def setup(api):
    cf = get_or_create(
        api.extras.custom_fields,
        dict(name=CF_NAME),
        dict(
            name=CF_NAME,
            label="CRM ID",
            type="text",
            object_types=["tenancy.tenant"],
            required=False,
        ),
    )
    tenant = get_or_create(
        api.tenancy.tenants,
        dict(slug=TENANT_SLUG),
        dict(name=TENANT_NAME, slug=TENANT_SLUG, custom_fields={CF_NAME: CF_VALUE}),
    )
    if tenant.custom_fields.get(CF_NAME) != CF_VALUE:
        tenant.update({"custom_fields": {CF_NAME: CF_VALUE}})
        tenant = api.tenancy.tenants.get(tenant.id)
    return cf, tenant


def teardown(cf, tenant):
    tenant.delete()
    cf.delete()


def main():
    api = pynetbox.api(NETBOX_URL, token=NETBOX_TOKEN, strict_filters=True)
    print(f"NetBox {api.version} at {NETBOX_URL} (strict_filters=True)")

    cf, tenant = setup(api)
    print(f"custom_field={cf.id} ({cf.name}={CF_VALUE}) tenant={tenant.id}")

    print(f"filter cf_{CF_NAME}={CF_VALUE} with strict_filters=True...")
    results = list(api.tenancy.tenants.filter(**{f"cf_{CF_NAME}": CF_VALUE}))
    print(f"  -> {len(results)} result(s): {[t.name for t in results]}")
    assert any(t.id == tenant.id for t in results), "tenant not returned by cf_ filter"

    print("filter with an invalid kwarg under strict_filters — must still raise...")
    try:
        api.tenancy.tenants.filter(definitely_not_a_param="x")
    except ParameterValidationError as exc:
        print(f"  raised as expected: {exc}")
    else:
        raise AssertionError("invalid kwarg did not raise ParameterValidationError")

    teardown(cf, tenant)
    print("PASS")


if __name__ == "__main__":
    sys.exit(main())
```