### PR TITLE
#749 - fix: don't treat Record methods as constructors in _parse_values

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -482,7 +482,7 @@ class Record:
                     self._add_cache((k, copy.deepcopy(v)))
                     setattr(self, k, v)
                     continue
-                if lookup:
+                if isinstance(lookup, type):
                     v = lookup(v, self.api, self.endpoint)
                 else:
                     v = self.default_ret(v, self.api, self.endpoint)

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -482,7 +482,7 @@ class Record:
                     self._add_cache((k, copy.deepcopy(v)))
                     setattr(self, k, v)
                     continue
-                if isinstance(lookup, type):
+                if isinstance(lookup, type) and issubclass(lookup, Record):
                     v = lookup(v, self.api, self.endpoint)
                 else:
                     v = self.default_ret(v, self.api, self.endpoint)

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -52,6 +52,18 @@ class RecordTestCase(unittest.TestCase):
         with self.assertRaises(KeyError) as _:
             test_obj["nothing"]
 
+    def test_nested_dict_key_collides_with_record_method(self):
+        # Regression for issue #749: a nested dict key like "updates"
+        # collided with Record.updates and was invoked as a constructor.
+        test_values = {
+            "id": 1,
+            "config_context": {"router_bgp": {"updates": {"wait_install": True}}},
+        }
+        test_obj = Record(test_values, Mock(base_url="http://test"), None)
+        self.assertEqual(
+            test_obj.config_context.router_bgp.updates.wait_install, True
+        )
+
     def test_serialize_list_of_records(self):
         test_values = {
             "id": 123,


### PR DESCRIPTION
### Fixes: #749 

- `Record._parse_values` looked up nested-dict field names with `getattr(self.__class__, k, None)` and invoked anything truthy as `lookup(v, api, endpoint)`. When a nested API payload contained a key matching a `Record` method name — e.g. `updates`, `save`, `delete`, `serialize` — the method was called as a constructor and raised `TypeError`.
- Narrowed the check to `isinstance(lookup, type)` so only class-typed field overrides take the constructor path; everything else falls through to `default_ret`. All in-tree model overrides in `pynetbox/models/*.py` are `Record` subclasses, so existing behavior is preserved.
- Added a regression test covering a nested `updates` key (the path that fails in the issue's repro).****