### PR TITLE
#774 - Add plugin extension framework

### DIFF
--- a/pynetbox/__init__.py
+++ b/pynetbox/__init__.py
@@ -1,10 +1,12 @@
 from pynetbox.core.api import Api
+from pynetbox.core.extension import Extension
 from pynetbox.core.query import (
     AllocationError,
     ContentError,
     RequestError,
     ParameterValidationError,
 )
+from pynetbox.core.response import JsonField
 
 __version__ = "7.7.0"
 
@@ -15,6 +17,8 @@ __all__ = (
     "Api",
     "AllocationError",
     "ContentError",
+    "Extension",
+    "JsonField",
     "RequestError",
     "ParameterValidationError",
     "api",

--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -121,6 +121,11 @@ class Api:
         ``App._setmodel`` can look up the right ``models`` namespace, and
         composes the built-in ``CONTENT_TYPE_MAPPER`` with each extension's
         ``content_types`` overrides.
+
+        Two extensions cannot share a ``plugin_name`` or register the same
+        content-type key — both raise ``ValueError``, since a silent
+        last-wins would mask a configuration mistake. Overriding a key from
+        the built-in ``CONTENT_TYPE_MAPPER`` is allowed and intentional.
         """
         self._extensions = {}
         for ext in extensions:
@@ -129,11 +134,26 @@ class Api:
                 raise ValueError(
                     "Extension {!r} is missing a 'plugin_name' attribute".format(ext)
                 )
+            if plugin_name in self._extensions:
+                raise ValueError(
+                    "Duplicate extension for plugin_name {!r}: {!r} and {!r}".format(
+                        plugin_name, self._extensions[plugin_name], ext
+                    )
+                )
             self._extensions[plugin_name] = ext
 
         content_types = dict(CONTENT_TYPE_MAPPER)
+        seen_extension_keys = {}
         for ext in self._extensions.values():
-            content_types.update(getattr(ext, "content_types", None) or {})
+            ext_content_types = getattr(ext, "content_types", None) or {}
+            for key, value in ext_content_types.items():
+                if key in seen_extension_keys:
+                    raise ValueError(
+                        "Duplicate content_type {!r} registered by extensions "
+                        "{!r} and {!r}".format(key, seen_extension_keys[key], ext)
+                    )
+                seen_extension_keys[key] = ext
+                content_types[key] = value
         self._content_type_mapper = content_types
         self._type_content_mapper = {
             v: k for k, v in content_types.items() if v is not None

--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -21,6 +21,7 @@ import requests
 from pynetbox.core.app import App, PluginsApp
 from pynetbox.core.query import Request, TOKEN_PREFIX
 from pynetbox.core.response import Record
+from pynetbox.models.mapper import CONTENT_TYPE_MAPPER
 
 
 class Api:
@@ -80,6 +81,7 @@ class Api:
         token=None,
         threading=False,
         strict_filters=False,
+        extensions=None,
     ):
         """Initialize the API client.
 
@@ -88,6 +90,7 @@ class Api:
             token (str, optional): Your NetBox API token. If not provided, authentication will be required for each request.
             threading (bool, optional): Set to True to use threading in `.all()` and `.filter()` requests, defaults to False.
             strict_filters (bool, optional): Set to True to check GET call filters against OpenAPI specifications (intentionally not done in NetBox API), defaults to False.
+            extensions (list, optional): A list of `Extension` classes or instances that register custom `Record` subclasses and content-type mappings for NetBox plugins. See `pynetbox.core.extension`.
         """
         base_url = "{}/api".format(url if url[-1] != "/" else url[:-1])
         self.token = token
@@ -95,6 +98,8 @@ class Api:
         self.http_session = requests.Session()
         self.threading = threading
         self.strict_filters = strict_filters
+
+        self._register_extensions(extensions or [])
 
         # Initialize NetBox apps
         self.circuits = App(self, "circuits")
@@ -108,6 +113,31 @@ class Api:
         self.vpn = App(self, "vpn")
         self.wireless = App(self, "wireless")
         self.plugins = PluginsApp(self)
+
+    def _register_extensions(self, extensions):
+        """Build per-instance extension and content-type registries.
+
+        Stores extensions keyed by ``plugin_name`` so ``PluginsApp`` and
+        ``App._setmodel`` can look up the right ``models`` namespace, and
+        composes the built-in ``CONTENT_TYPE_MAPPER`` with each extension's
+        ``content_types`` overrides.
+        """
+        self._extensions = {}
+        for ext in extensions:
+            plugin_name = getattr(ext, "plugin_name", None)
+            if not plugin_name:
+                raise ValueError(
+                    "Extension {!r} is missing a 'plugin_name' attribute".format(ext)
+                )
+            self._extensions[plugin_name] = ext
+
+        content_types = dict(CONTENT_TYPE_MAPPER)
+        for ext in self._extensions.values():
+            content_types.update(getattr(ext, "content_types", None) or {})
+        self._content_type_mapper = content_types
+        self._type_content_mapper = {
+            v: k for k, v in content_types.items() if v is not None
+        }
 
     @property
     def version(self):

--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -126,6 +126,11 @@ class Api:
         content-type key — both raise ``ValueError``, since a silent
         last-wins would mask a configuration mistake. Overriding a key from
         the built-in ``CONTENT_TYPE_MAPPER`` is allowed and intentional.
+
+        ``plugin_name`` is normalized by converting dashes to underscores
+        before lookup so the same plugin cannot register itself twice
+        under both spellings (e.g. ``"custom-objects"`` and
+        ``"custom_objects"``).
         """
         self._extensions = {}
         for ext in extensions:
@@ -134,6 +139,7 @@ class Api:
                 raise ValueError(
                     "Extension {!r} is missing a 'plugin_name' attribute".format(ext)
                 )
+            plugin_name = plugin_name.replace("-", "_")
             if plugin_name in self._extensions:
                 raise ValueError(
                     "Duplicate extension for plugin_name {!r}: {!r} and {!r}".format(

--- a/pynetbox/core/app.py
+++ b/pynetbox/core/app.py
@@ -56,8 +56,21 @@ class App:
         "wireless": wireless,
     }
 
+    _PLUGINS_PREFIX = "plugins/"
+
     def _setmodel(self):
-        self.model = App.models[self.name] if self.name in App.models else None
+        if self.name.startswith(self._PLUGINS_PREFIX):
+            # Plugin apps may carry a custom models namespace registered
+            # via an Extension. The plugin attribute uses underscores while
+            # the URL slug uses dashes (PluginsApp.__getattr__), so convert
+            # back when looking up the registry.
+            plugin_slug = self.name[len(self._PLUGINS_PREFIX) :]
+            plugin_name = plugin_slug.replace("-", "_")
+            extensions = getattr(self.api, "_extensions", {})
+            ext = extensions.get(plugin_name)
+            self.model = getattr(ext, "models", None) if ext is not None else None
+        else:
+            self.model = App.models.get(self.name)
 
     def __getstate__(self):
         return {"api": self.api, "name": self.name}

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -636,24 +636,29 @@ class DetailEndpoint:
             ]
         return req
 
-    def create(self, data=None):
+    def create(self, data=None, **kwargs):
         """The write operation for a detail endpoint.
 
         Creates objects on a detail endpoint in NetBox.
 
         ## Parameters
 
-        * **data** (dict/list, optional): A dictionary containing the
+        * **data** (dict/list, optional): A dictionary or list containing the
             key/value pair of the items you're creating on the parent
             object. Defaults to empty dict which will create a single
             item with default values.
+        * **kwargs**: Alternative to `data`, fields and values to create
+            the object with — mirrors `Endpoint.create()`. Cannot be
+            combined with `data`.
 
         ## Returns
         A Record object or list of Record objects created
         from data created in NetBox.
         """
-        data = data or {}
-        req = Request(**self.request_kwargs).post(data)
+        if data is not None and kwargs:
+            raise ValueError("Cannot pass both data and keyword arguments")
+        payload = data if data is not None else kwargs
+        req = Request(**self.request_kwargs).post(payload)
         if self.custom_return:
             if isinstance(req, list):
                 return [
@@ -670,7 +675,7 @@ class DetailEndpoint:
 
 
 class RODetailEndpoint(DetailEndpoint):
-    def create(self, data):
+    def create(self, data=None, **kwargs):
         raise NotImplementedError("Writes are not supported for this endpoint.")
 
 

--- a/pynetbox/core/extension.py
+++ b/pynetbox/core/extension.py
@@ -6,9 +6,15 @@ content-type mappings without modifying pynetbox itself.
 
 An extension is any object (typically a class) exposing:
 
-* ``plugin_name`` (str): the plugin's slug as it appears under ``nb.plugins``
-  (e.g. ``"branching"`` for ``nb.plugins.branching``). Underscores in the
-  attribute access map to dashes in the URL, matching the existing
+* ``plugin_name`` (str): the plugin's API URL slug as used under
+  ``/api/plugins/`` — *not* the plugin's Python package name or
+  ``PluginConfig.name``. For example, the ``netbox-acls`` plugin
+  serves ``/api/plugins/access-lists/`` so its ``plugin_name`` is
+  ``"access_lists"`` (or equivalently ``"access-lists"``).
+  Dashes are normalized to underscores on registration, so the
+  same plugin cannot be registered twice under both spellings.
+  The attribute access ``nb.plugins.<plugin_name>`` then converts
+  underscores back to dashes for the URL, matching the existing
   ``PluginsApp`` convention.
 * ``models``: a namespace (module, class, or any object) from which
   ``Record`` subclasses can be resolved by title-cased endpoint name —

--- a/pynetbox/core/extension.py
+++ b/pynetbox/core/extension.py
@@ -1,0 +1,62 @@
+"""
+Extension framework for pynetbox.
+
+Lets third-party NetBox plugins ship custom ``Record`` subclasses and
+content-type mappings without modifying pynetbox itself.
+
+An extension is any object (typically a class) exposing:
+
+* ``plugin_name`` (str): the plugin's slug as it appears under ``nb.plugins``
+  (e.g. ``"branching"`` for ``nb.plugins.branching``). Underscores in the
+  attribute access map to dashes in the URL, matching the existing
+  ``PluginsApp`` convention.
+* ``models``: a namespace (module, class, or any object) from which
+  ``Record`` subclasses can be resolved by title-cased endpoint name —
+  the same lookup used for built-in apps. For ``nb.plugins.<x>.branches``
+  pynetbox will look up ``models.Branches``.
+* ``content_types`` (dict, optional): maps NetBox content-type strings
+  (e.g. ``"netbox_branching.branch"``) to ``Record`` subclasses, so the
+  classes are used when resolving polymorphic nested objects.
+
+## Example
+
+```python
+from pynetbox import api, Extension, JsonField
+from pynetbox.core.response import Record
+from pynetbox.core.endpoint import DetailEndpoint
+
+
+class Branches(Record):
+    @property
+    def merge(self):
+        return DetailEndpoint(self, "merge")
+
+
+class BranchingModels:
+    Branches = Branches
+
+
+class BranchingExtension(Extension):
+    plugin_name = "branching"
+    models = BranchingModels
+
+
+nb = api("http://localhost:8000", token="...", extensions=[BranchingExtension])
+branch = nb.plugins.branching.branches.get(1)
+branch.merge.create(commit=True)
+```
+"""
+
+
+class Extension:
+    """Base class for pynetbox extensions.
+
+    Subclassing is optional — any object with the required attributes is
+    accepted. The base class exists so extension authors have an explicit
+    contract to target and so ``isinstance`` checks are available to
+    downstream code that wants them.
+    """
+
+    plugin_name: str = ""
+    models = None
+    content_types: dict = {}

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -448,13 +448,17 @@ class Record:
         def generic_list_parser(key_name, list_item):
             from pynetbox.models.mapper import CONTENT_TYPE_MAPPER
 
+            content_type_mapper = getattr(
+                self.api, "_content_type_mapper", CONTENT_TYPE_MAPPER
+            )
+
             if (
                 isinstance(list_item, dict)
                 and "object_type" in list_item
                 and "object" in list_item
             ):
                 lookup = list_item["object_type"]
-                if model := CONTENT_TYPE_MAPPER.get(lookup, None):
+                if model := content_type_mapper.get(lookup, None):
                     record = model(list_item["object"], self.api, self.endpoint)
                     return GenericListObject(record)
 
@@ -806,9 +810,13 @@ class GenericListObject:
     def __init__(self, record):
         from pynetbox.models.mapper import TYPE_CONTENT_MAPPER
 
+        type_content_mapper = getattr(
+            record.api, "_type_content_mapper", TYPE_CONTENT_MAPPER
+        )
+
         self.object = record
         self.object_id = record.id
-        self.object_type = TYPE_CONTENT_MAPPER.get(record.__class__)
+        self.object_type = type_content_mapper.get(record.__class__)
 
     def __repr__(self):
         return str(self.object)

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -496,7 +496,13 @@ class Record:
                 # check if GFK
                 if len(v) and isinstance(v[0], dict) and "object_type" in v[0]:
                     v = [generic_list_parser(k, i) for i in v]
-                    to_cache = [i.serialize() for i in v]
+                    # An unmapped object_type (e.g. a plugin whose extension
+                    # hasn't been registered) falls through as the raw dict,
+                    # so cache it directly instead of assuming .serialize().
+                    to_cache = [
+                        i.serialize() if hasattr(i, "serialize") else copy.deepcopy(i)
+                        for i in v
+                    ]
                 elif k == "constraints":
                     # Permissions constraints can be either dict or list
                     to_cache = copy.deepcopy(v)

--- a/tests/unit/test_detailendpoint.py
+++ b/tests/unit/test_detailendpoint.py
@@ -35,6 +35,32 @@ class DetailEndpointTestCase(unittest.TestCase):
             ip_obj = ip_range_obj.available_ips.create()
             self.assertEqual(ip_obj.address, "1.2.4.2/24")
 
+    def test_detail_endpoint_create_kwargs(self):
+        """Detail endpoints accept kwargs in the same spirit as Endpoint.create()."""
+        with patch(
+            "pynetbox.core.query.Request._make_call",
+            return_value={"id": 123, "prefix": "1.2.3.0/24"},
+        ):
+            prefix_obj = nb.ipam.prefixes.get(123)
+        with patch(
+            "pynetbox.core.query.Request._make_call",
+            return_value={"address": "1.2.3.1/24"},
+        ) as mock_call:
+            ip_obj = prefix_obj.available_ips.create(description="example")
+            mock_call.assert_called_once_with(
+                verb="post", data={"description": "example"}
+            )
+            self.assertEqual(ip_obj.address, "1.2.3.1/24")
+
+    def test_detail_endpoint_create_rejects_data_and_kwargs(self):
+        with patch(
+            "pynetbox.core.query.Request._make_call",
+            return_value={"id": 123, "prefix": "1.2.3.0/24"},
+        ):
+            prefix_obj = nb.ipam.prefixes.get(123)
+        with self.assertRaises(ValueError):
+            prefix_obj.available_ips.create({"description": "x"}, commit=True)
+
     def test_detail_endpoint_create_list(self):
         # Prefixes
         with patch(

--- a/tests/unit/test_extensions.py
+++ b/tests/unit/test_extensions.py
@@ -77,6 +77,35 @@ class ExtensionRegistrationTestCase(unittest.TestCase):
                 extensions=[BranchingExtension, OtherBranchingExtension],
             )
 
+    def test_plugin_name_dash_underscore_equivalent(self):
+        """plugin_name 'custom-objects' and 'custom_objects' are the same key."""
+
+        class DashExtension(Extension):
+            plugin_name = "custom-objects"
+            models = CustomObjectsModels
+
+        class UnderscoreExtension(Extension):
+            plugin_name = "custom_objects"
+            models = CustomObjectsModels
+
+        with self.assertRaisesRegex(ValueError, "Duplicate extension"):
+            pynetbox.api(
+                "http://localhost:8000",
+                token="abc",
+                extensions=[DashExtension, UnderscoreExtension],
+            )
+
+    def test_plugin_name_dashed_registers_under_underscored_key(self):
+        class DashExtension(Extension):
+            plugin_name = "access-lists"
+            models = BranchingModels
+
+        nb = pynetbox.api(
+            "http://localhost:8000", token="abc", extensions=[DashExtension]
+        )
+        self.assertIn("access_lists", nb._extensions)
+        self.assertNotIn("access-lists", nb._extensions)
+
     def test_duplicate_content_type_across_extensions_raises(self):
         class ConflictingExtension(Extension):
             plugin_name = "other_plugin"
@@ -255,3 +284,55 @@ class GenericListExtensionTestCase(unittest.TestCase):
             Mock(spec=Endpoint),
         )
         self.assertIsInstance(record.things[0].object, CustomObjectTypeFields)
+
+    def test_unmapped_object_type_preserved_as_dict(self):
+        """An unregistered plugin object_type stays as the raw dict instead of crashing.
+
+        Real-world case: a NetBox instance returns generic-list items from
+        a plugin the caller hasn't added an extension for. Parsing should
+        not raise.
+        """
+        nb = pynetbox.api("http://localhost:8000", token="abc")
+        raw_item = {
+            "object_type": "some_plugin.some_model",
+            "object": {"id": 9, "name": "unknown"},
+        }
+        record = Record(
+            {"id": 1, "things": [raw_item]},
+            nb,
+            Mock(spec=Endpoint),
+        )
+        self.assertEqual(record.things, [raw_item])
+
+    def test_unmapped_and_mapped_object_types_mixed(self):
+        """Mapped entries become GenericListObject; unmapped entries stay raw dicts."""
+        nb = pynetbox.api(
+            "http://localhost:8000",
+            token="abc",
+            extensions=[CustomObjectsExtension],
+        )
+        record = Record(
+            {
+                "id": 1,
+                "things": [
+                    {
+                        "object_type": "custom_objects.customobjecttypefield",
+                        "object": {"id": 9, "name": "cidr_list"},
+                    },
+                    {
+                        "object_type": "some_plugin.some_model",
+                        "object": {"id": 10, "name": "unknown"},
+                    },
+                ],
+            },
+            nb,
+            Mock(spec=Endpoint),
+        )
+        self.assertIsInstance(record.things[0].object, CustomObjectTypeFields)
+        self.assertEqual(
+            record.things[1],
+            {
+                "object_type": "some_plugin.some_model",
+                "object": {"id": 10, "name": "unknown"},
+            },
+        )

--- a/tests/unit/test_extensions.py
+++ b/tests/unit/test_extensions.py
@@ -1,0 +1,212 @@
+import unittest
+from unittest.mock import Mock, patch
+
+import pynetbox
+from pynetbox.core.endpoint import DetailEndpoint, Endpoint
+from pynetbox.core.extension import Extension
+from pynetbox.core.response import JsonField, Record
+
+
+# Models used by the extensions defined below. Modeled after the shapes
+# called out in netbox-community/pynetbox#710 and #745 #751.
+
+
+class Branches(Record):
+    """Plugin Record subclass with a custom DetailEndpoint, like #710."""
+
+    @property
+    def merge(self):
+        return DetailEndpoint(self, "merge")
+
+
+class BranchingModels:
+    Branches = Branches
+
+
+class BranchingExtension(Extension):
+    plugin_name = "branching"
+    models = BranchingModels
+
+
+class CustomObjectTypeFields(Record):
+    """Plugin Record marking a dict field as JSON, like #751."""
+
+    related_object_filter = JsonField
+
+
+class CustomObjectsModels:
+    CustomObjectTypeFields = CustomObjectTypeFields
+
+
+class CustomObjectsExtension(Extension):
+    plugin_name = "custom_objects"
+    models = CustomObjectsModels
+    content_types = {
+        "custom_objects.customobjecttypefield": CustomObjectTypeFields,
+    }
+
+
+class ExtensionRegistrationTestCase(unittest.TestCase):
+    def test_extension_registry_built(self):
+        nb = pynetbox.api(
+            "http://localhost:8000",
+            token="abc",
+            extensions=[BranchingExtension, CustomObjectsExtension],
+        )
+        self.assertIn("branching", nb._extensions)
+        self.assertIn("custom_objects", nb._extensions)
+
+    def test_missing_plugin_name_raises(self):
+        class BadExtension:
+            models = None
+
+        with self.assertRaises(ValueError):
+            pynetbox.api(
+                "http://localhost:8000", token="abc", extensions=[BadExtension]
+            )
+
+    def test_content_types_merged_into_mapper(self):
+        nb = pynetbox.api(
+            "http://localhost:8000",
+            token="abc",
+            extensions=[CustomObjectsExtension],
+        )
+        self.assertIs(
+            nb._content_type_mapper["custom_objects.customobjecttypefield"],
+            CustomObjectTypeFields,
+        )
+        # Reverse mapping is rebuilt as well.
+        self.assertEqual(
+            nb._type_content_mapper[CustomObjectTypeFields],
+            "custom_objects.customobjecttypefield",
+        )
+        # Built-in mappings are preserved.
+        self.assertIn("dcim.cable", nb._content_type_mapper)
+
+
+class PluginEndpointResolutionTestCase(unittest.TestCase):
+    def test_plugin_endpoint_uses_extension_record(self):
+        """An endpoint under nb.plugins.<name> resolves to the extension's Record."""
+        nb = pynetbox.api(
+            "http://localhost:8000",
+            token="abc",
+            extensions=[BranchingExtension],
+        )
+        endpoint = nb.plugins.branching.branches
+        self.assertIs(endpoint.return_obj, Branches)
+
+    def test_plugin_without_extension_falls_back_to_record(self):
+        nb = pynetbox.api("http://localhost:8000", token="abc")
+        endpoint = nb.plugins.unknown_plugin.things
+        self.assertIs(endpoint.return_obj, Record)
+
+    def test_plugin_endpoint_with_dashed_slug(self):
+        """Extension plugin_name 'custom_objects' matches URL slug 'custom-objects'."""
+        nb = pynetbox.api(
+            "http://localhost:8000",
+            token="abc",
+            extensions=[CustomObjectsExtension],
+        )
+        endpoint = nb.plugins.custom_objects.custom_object_type_fields
+        self.assertIs(endpoint.return_obj, CustomObjectTypeFields)
+        # URL slug should still use dashes per existing convention.
+        self.assertEqual(
+            endpoint.url,
+            "http://localhost:8000/api/plugins/custom-objects/custom-object-type-fields",
+        )
+
+
+class PluginRecordBehaviorTestCase(unittest.TestCase):
+    def test_detail_endpoint_on_plugin_record(self):
+        """#710 shape: plugin Record exposes DetailEndpoint via @property."""
+        with patch("pynetbox.core.query.Request._make_call") as mock:
+            mock.return_value = [{"id": 1, "name": "feature-branch"}]
+            nb = pynetbox.api(
+                "http://localhost:8000",
+                token="abc",
+                extensions=[BranchingExtension],
+            )
+            branch = nb.plugins.branching.branches.get(1)
+            self.assertIsInstance(branch, Branches)
+            self.assertIsInstance(branch.merge, DetailEndpoint)
+            self.assertTrue(branch.merge.url.endswith("/branches/1/merge/"))
+
+    def test_jsonfield_preserves_dict_on_plugin_record(self):
+        """#751 shape: a JSON dict field on a plugin record stays a dict."""
+        payload = {
+            "id": 3,
+            "name": "cidr_list",
+            "related_object_filter": {
+                "vrf__n": "null",
+                "tenant_group": "aws-accounts",
+                "mask_length__lte": 28,
+            },
+        }
+        with patch(
+            "pynetbox.core.query.Request._make_call", return_value=[payload]
+        ):
+            nb = pynetbox.api(
+                "http://localhost:8000",
+                token="abc",
+                extensions=[CustomObjectsExtension],
+            )
+            field = nb.plugins.custom_objects.custom_object_type_fields.get(3)
+            self.assertIsInstance(field, CustomObjectTypeFields)
+            self.assertEqual(
+                field.related_object_filter,
+                {
+                    "vrf__n": "null",
+                    "tenant_group": "aws-accounts",
+                    "mask_length__lte": 28,
+                },
+            )
+            # And round-trips through serialize().
+            self.assertEqual(
+                field.serialize()["related_object_filter"],
+                {
+                    "vrf__n": "null",
+                    "tenant_group": "aws-accounts",
+                    "mask_length__lte": 28,
+                },
+            )
+
+
+class PluginAppPickleTestCase(unittest.TestCase):
+    def test_plugin_app_setstate_restores_model(self):
+        """App.__setstate__ should re-resolve the extension's models on unpickle."""
+        import pickle
+
+        nb = pynetbox.api(
+            "http://localhost:8000",
+            token="abc",
+            extensions=[BranchingExtension],
+        )
+        app = nb.plugins.branching
+        round_tripped = pickle.loads(pickle.dumps(app))
+        # After unpickle, the model should still resolve to BranchingModels
+        # because _setmodel re-consults the api's extension registry.
+        self.assertIs(round_tripped.model, BranchingModels)
+
+
+class GenericListExtensionTestCase(unittest.TestCase):
+    def test_extension_record_used_for_gfk(self):
+        """A polymorphic list item with a plugin content_type uses the extension Record."""
+        nb = pynetbox.api(
+            "http://localhost:8000",
+            token="abc",
+            extensions=[CustomObjectsExtension],
+        )
+        record = Record(
+            {
+                "id": 1,
+                "things": [
+                    {
+                        "object_type": "custom_objects.customobjecttypefield",
+                        "object": {"id": 9, "name": "cidr_list"},
+                    }
+                ],
+            },
+            nb,
+            Mock(spec=Endpoint),
+        )
+        self.assertIsInstance(record.things[0].object, CustomObjectTypeFields)

--- a/tests/unit/test_extensions.py
+++ b/tests/unit/test_extensions.py
@@ -65,6 +65,51 @@ class ExtensionRegistrationTestCase(unittest.TestCase):
                 "http://localhost:8000", token="abc", extensions=[BadExtension]
             )
 
+    def test_duplicate_plugin_name_raises(self):
+        class OtherBranchingExtension(Extension):
+            plugin_name = "branching"
+            models = BranchingModels
+
+        with self.assertRaisesRegex(ValueError, "Duplicate extension"):
+            pynetbox.api(
+                "http://localhost:8000",
+                token="abc",
+                extensions=[BranchingExtension, OtherBranchingExtension],
+            )
+
+    def test_duplicate_content_type_across_extensions_raises(self):
+        class ConflictingExtension(Extension):
+            plugin_name = "other_plugin"
+            models = CustomObjectsModels
+            content_types = {
+                "custom_objects.customobjecttypefield": CustomObjectTypeFields,
+            }
+
+        with self.assertRaisesRegex(ValueError, "Duplicate content_type"):
+            pynetbox.api(
+                "http://localhost:8000",
+                token="abc",
+                extensions=[CustomObjectsExtension, ConflictingExtension],
+            )
+
+    def test_extension_can_override_builtin_content_type(self):
+        """Overriding a built-in CONTENT_TYPE_MAPPER entry is allowed."""
+
+        class CableOverride(Record):
+            pass
+
+        class CableOverrideExtension(Extension):
+            plugin_name = "cable_override"
+            models = None
+            content_types = {"dcim.cable": CableOverride}
+
+        nb = pynetbox.api(
+            "http://localhost:8000",
+            token="abc",
+            extensions=[CableOverrideExtension],
+        )
+        self.assertIs(nb._content_type_mapper["dcim.cable"], CableOverride)
+
     def test_content_types_merged_into_mapper(self):
         nb = pynetbox.api(
             "http://localhost:8000",


### PR DESCRIPTION
### Fixes: #774 

Adds a plugin extension framework so NetBox plugins (or pynetbox itself) can register custom `Record` subclasses, JSON-field markers, and content-type mappings for `nb.plugins.<x>` endpoints — without modifying core pynetbox.

Foundation for the shipped extensions (e.g. #776 branching, #777 custom objects), and also usable by third parties who want typed records for their own plugins.

## Contract

An extension is any object exposing:

- **`plugin_name`** (str) — slug under `nb.plugins` (e.g. `"branching"` for `nb.plugins.branching`). Underscores map to dashes in the URL, matching the existing convention.
- **`models`** — a namespace (module, class, or instance) from which `Record` subclasses are resolved by title-cased endpoint name (e.g. `getattr(models, "Branches")` for `nb.plugins.branching.branches`).
- **`content_types`** (dict, optional) — maps NetBox content-type strings to `Record` subclasses so polymorphic nested objects deserialize correctly.

Subclassing `pynetbox.Extension` is optional; the base class exists to give authors an explicit contract.

## Usage

```python
import pynetbox
from pynetbox import Extension
from pynetbox.core.response import JsonField, Record


class Branches(Record):
    pass


class BranchingModels:
    Branches = Branches


class BranchingExtension(Extension):
    plugin_name = "branching"
    models = BranchingModels
    content_types = {"netbox_branching.branch": Branches}


nb = pynetbox.api(url, token="...", extensions=[BranchingExtension])
```

What it changes

- pynetbox/core/extension.py — new Extension base class.
- Api.__init__ — accepts extensions=[...]; builds per-instance _extensions and _content_type_mapper registries. Duplicate plugin_name or content-type keys raise ValueError; overriding a built-in CONTENT_TYPE_MAPPER entry is allowed.
- App._setmodel — looks up plugin models via the registry for plugins/<slug> apps.
- Record._parse_values and GenericListObject — use the per-instance content-type mapper instead of the global one, so extension records participate in GFK resolution.
- pynetbox/__init__.py — exports Extension.