### PR TITLE
#519 - fix link peer casting

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -24,6 +24,11 @@ from pynetbox.core.util import Hashabledict
 # List of fields that are lists but should be treated as sets.
 LIST_AS_SET = ("tags", "tagged_vlans")
 
+# List fields whose item type is announced via a sibling "<field>_type"
+# content-type string (NetBox's CableTerminationModelSerializerMixin pattern).
+# Items are cast to the Record subclass named by that sibling content type.
+SIBLING_TYPED_LIST_FIELDS = ("link_peers", "connected_endpoints")
+
 
 def get_return(lookup, return_fields=None):
     """Returns simple representations for items passed to lookup.
@@ -477,6 +482,19 @@ class Record:
 
             return list_item
 
+        def sibling_typed_list_parser(list_item, content_type):
+            from pynetbox.models.mapper import CONTENT_TYPE_MAPPER
+
+            content_type_mapper = getattr(
+                self.api, "_content_type_mapper", CONTENT_TYPE_MAPPER
+            )
+
+            if isinstance(list_item, dict):
+                if model := content_type_mapper.get(content_type, None):
+                    return model(list_item, self.api, self.endpoint)
+                return self.default_ret(list_item, self.api, self.endpoint)
+            return list_item
+
         for k, v in values.items():
             if isinstance(v, dict):
                 lookup = getattr(self.__class__, k, None)
@@ -506,6 +524,19 @@ class Record:
                 elif k == "constraints":
                     # Permissions constraints can be either dict or list
                     to_cache = copy.deepcopy(v)
+                elif (
+                    k in SIBLING_TYPED_LIST_FIELDS
+                    and len(v)
+                    and isinstance(v[0], dict)
+                    and isinstance(values.get(f"{k}_type"), str)
+                ):
+                    # NetBox cable-termination pattern: link_peers/
+                    # connected_endpoints carry their item type in the sibling
+                    # link_peers_type/connected_endpoints_type field rather
+                    # than per-item. Cast each item to the model named by
+                    # that sibling content type.
+                    v = [sibling_typed_list_parser(i, values[f"{k}_type"]) for i in v]
+                    to_cache = list(v)
                 else:
                     v = [list_parser(k, i) for i in v]
                     to_cache = list(v)

--- a/pynetbox/models/circuits.py
+++ b/pynetbox/models/circuits.py
@@ -53,3 +53,12 @@ class VirtualCircuitTerminations(PathableRecord):
 
     def __str__(self):
         return self.virtual_circuit.cid
+
+
+class ProviderNetworks(Record):
+    """Provider Network Record.
+
+    Represents an upstream provider's network — a connectivity endpoint
+    delivered by a provider that can terminate a circuit without an
+    on-premise device.
+    """

--- a/pynetbox/models/mapper.py
+++ b/pynetbox/models/mapper.py
@@ -1,6 +1,7 @@
 from .circuits import (
     Circuits,
     CircuitTerminations,
+    ProviderNetworks,
     VirtualCircuits,
     VirtualCircuitTerminations,
 )
@@ -29,6 +30,7 @@ from .wireless import WirelessLans
 CONTENT_TYPE_MAPPER = {
     "circuits.circuit": Circuits,
     "circuits.circuittermination": CircuitTerminations,
+    "circuits.providernetwork": ProviderNetworks,
     "circuits.virtualcircuit": VirtualCircuits,
     "circuits.virtualcircuittermination": VirtualCircuitTerminations,
     "core.datasource": DataSources,

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -564,6 +564,108 @@ class RecordTestCase(unittest.TestCase):
         ]:
             self.assertNotIn(attr, serialized)
 
+    def test_link_peers_typed_by_sibling_content_type(self):
+        """Regression for issue #519: link_peers items should be cast to the
+        Record subclass identified by the sibling link_peers_type field."""
+        import pynetbox
+        from pynetbox.models.circuits import CircuitTerminations
+
+        nb = pynetbox.api("http://localhost:8000", token="abc")
+        record = Record(
+            {
+                "id": 7,
+                "name": "et-0/0/0",
+                "link_peers": [
+                    {
+                        "id": 1,
+                        "url": "http://localhost:8000/api/circuits/circuit-terminations/1/",
+                        "display": "Termination A",
+                    }
+                ],
+                "link_peers_type": "circuits.circuittermination",
+            },
+            nb,
+            Mock(spec=Endpoint),
+        )
+        self.assertEqual(len(record.link_peers), 1)
+        self.assertIsInstance(record.link_peers[0], CircuitTerminations)
+        self.assertEqual(record.link_peers[0].id, 1)
+
+    def test_connected_endpoints_typed_by_sibling_content_type(self):
+        """Regression for issue #519: connected_endpoints items should be cast
+        to the Record subclass identified by the sibling
+        connected_endpoints_type field."""
+        import pynetbox
+        from pynetbox.models.dcim import Interfaces
+
+        nb = pynetbox.api("http://localhost:8000", token="abc")
+        record = Record(
+            {
+                "id": 7,
+                "name": "et-0/0/0",
+                "connected_endpoints": [
+                    {
+                        "id": 22,
+                        "url": "http://localhost:8000/api/dcim/interfaces/22/",
+                        "display": "eth0",
+                        "name": "eth0",
+                    }
+                ],
+                "connected_endpoints_type": "dcim.interface",
+                "connected_endpoints_reachable": True,
+            },
+            nb,
+            Mock(spec=Endpoint),
+        )
+        self.assertEqual(len(record.connected_endpoints), 1)
+        self.assertIsInstance(record.connected_endpoints[0], Interfaces)
+        self.assertEqual(record.connected_endpoints[0].name, "eth0")
+
+    def test_sibling_type_null_falls_back_to_default(self):
+        """A null sibling type (no link peer present) should leave the empty
+        list alone and not raise."""
+        import pynetbox
+
+        nb = pynetbox.api("http://localhost:8000", token="abc")
+        record = Record(
+            {
+                "id": 7,
+                "name": "et-0/0/0",
+                "link_peers": [],
+                "link_peers_type": None,
+            },
+            nb,
+            Mock(spec=Endpoint),
+        )
+        self.assertEqual(record.link_peers, [])
+        self.assertIsNone(record.link_peers_type)
+
+    def test_sibling_type_unmapped_falls_back_to_default_record(self):
+        """If the sibling content type isn't in the mapper, items still
+        become Records rather than raw dicts."""
+        import pynetbox
+
+        nb = pynetbox.api("http://localhost:8000", token="abc")
+        record = Record(
+            {
+                "id": 7,
+                "name": "et-0/0/0",
+                "link_peers": [
+                    {
+                        "id": 99,
+                        "url": "http://localhost:8000/api/some_plugin/some_models/99/",
+                        "display": "plugin obj",
+                    }
+                ],
+                "link_peers_type": "some_plugin.some_model",
+            },
+            nb,
+            Mock(spec=Endpoint),
+        )
+        self.assertEqual(len(record.link_peers), 1)
+        self.assertIsInstance(record.link_peers[0], Record)
+        self.assertEqual(record.link_peers[0].id, 99)
+
 
 class RecordSetTestCase(unittest.TestCase):
     ids = [1, 3, 5]


### PR DESCRIPTION
### Fixes: #519 

`link_peers` and `connected_endpoints` items on cable terminations are now cast to their proper Record subclass (e.g. Interfaces, CircuitTerminations) instead of generic Record. 

Also added a ProviderNetworks model and registered circuits.providernetwork in CONTENT_TYPE_MAPPER so circuit-to-provider-network peers resolve through the same path.

Sample script to show the casting below, will need to change API key to run.

 <details>
  <summary>Sample script showing casting</summary>

  ```python
#!/usr/bin/env python3
"""Manual test for issue #519: link_peers / connected_endpoints typing.

Walks cable-terminating endpoints (interfaces, console ports, power ports,
front/rear ports, circuit terminations) and prints the contents of their
``link_peers``/``link_peers_type`` and ``connected_endpoints``/
``connected_endpoints_type`` fields, showing the resolved Python class for
each list item. Before the fix each item was a generic ``Record``; after the
fix items resolve to their proper subclass (e.g. ``Interfaces``,
``CircuitTerminations``, ``FrontPorts``).
"""

import os
import sys

sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

import pynetbox
from pynetbox.core.response import Record

NETBOX_URL = os.environ.get("NETBOX_URL", "http://localhost:8000")
NETBOX_TOKEN = os.environ.get(
    "NETBOX_TOKEN", "nbt_NxFf0RnXEqwr.wZBsMOrjqF81BXr0vNV36znzqVDDCrJ5RxKG3sfw"
)

ENDPOINTS_TO_SCAN = [
    ("dcim", "interfaces"),
    ("dcim", "console_ports"),
    ("dcim", "console_server_ports"),
    ("dcim", "power_ports"),
    ("dcim", "power_outlets"),
    ("dcim", "front_ports"),
    ("dcim", "rear_ports"),
    ("circuits", "circuit_terminations"),
]

MAX_PER_ENDPOINT = 5


def describe_peer(peer):
    base = type(peer).__name__
    if isinstance(peer, Record):
        return "{} id={} display={!r}".format(
            base,
            getattr(peer, "id", None),
            getattr(peer, "display", None) or getattr(peer, "name", None),
        )
    return "{} {!r}".format(base, peer)


def dump_termination(label, obj):
    link_peers = getattr(obj, "link_peers", None) or []
    link_peers_type = getattr(obj, "link_peers_type", None)
    connected = getattr(obj, "connected_endpoints", None) or []
    connected_type = getattr(obj, "connected_endpoints_type", None)

    if not link_peers and not connected:
        return False

    print("\n{} id={} {!r}".format(label, obj.id, str(obj)))
    print("  link_peers_type: {!r}".format(link_peers_type))
    for i, peer in enumerate(link_peers):
        print("  link_peers[{}]: {}".format(i, describe_peer(peer)))
    print("  connected_endpoints_type: {!r}".format(connected_type))
    for i, peer in enumerate(connected):
        print("  connected_endpoints[{}]: {}".format(i, describe_peer(peer)))
    return True


def main():
    print("=" * 80)
    print("Issue #519: link_peers / connected_endpoints typing")
    print("Connecting to {}".format(NETBOX_URL))
    print("=" * 80)

    api = pynetbox.api(NETBOX_URL, token=NETBOX_TOKEN)
    print("NetBox version: {}".format(api.version))

    total_printed = 0
    for app_name, endpoint_name in ENDPOINTS_TO_SCAN:
        app = getattr(api, app_name)
        endpoint = getattr(app, endpoint_name)
        print("\n--- {}.{} (cabled) ---".format(app_name, endpoint_name))

        try:
            results = endpoint.filter(cabled=True)
        except Exception as exc:
            print("  skipped: {}".format(exc))
            continue

        printed = 0
        for obj in results:
            if printed >= MAX_PER_ENDPOINT:
                break
            label = "{}.{}".format(app_name, endpoint_name)
            if dump_termination(label, obj):
                printed += 1
        if printed == 0:
            print("  (no terminations with link peers found)")
        total_printed += printed

    print("\n" + "=" * 80)
    print("Printed {} terminations with link peers.".format(total_printed))
    print("=" * 80)
    return 0


if __name__ == "__main__":
    sys.exit(main())

  ```

  </details>