### PR TITLE
#625 reserve JSON list fields instead of returning them as Records

### DIFF
--- a/docs/custom-objects.md
+++ b/docs/custom-objects.md
@@ -38,7 +38,7 @@ cot.fields[0].related_object_type           # dict {"id", "app_label", "model"}
 `fields` is a nested list of `CustomObjectTypeFields` records, so attribute access on each item works as expected.
 
 !!! note "`related_object_types` (plural)"
-    On polymorphic Object/MultiObject fields the server returns `related_object_types` as a list of `{id, app_label, model}` dicts. pynetbox wraps each list item in a base `Record` (the `JsonField` marker only applies to dict-valued attributes, not list elements), so `field.related_object_types[0].app_label` works, but `isinstance(field.related_object_types[0], dict)` is `False` — unlike the singular `related_object_type`, which round-trips as a plain dict.
+    On polymorphic Object/MultiObject fields the server returns `related_object_types` as a list of `{id, app_label, model}` dicts. This field is not marked `JsonField`, so pynetbox wraps each list item in a base `Record`, so `field.related_object_types[0].app_label` works, but `isinstance(field.related_object_types[0], dict)` is `False` — unlike the singular `related_object_type`, which is marked `JsonField` and round-trips as a plain dict. (Marking a list-valued column `JsonField` keeps its items as plain dicts.)
 
 ## Custom Objects (per-type endpoints)
 

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -511,6 +511,15 @@ class Record:
                 self._add_cache((k, v))
 
             elif isinstance(v, list):
+                lookup = getattr(self.__class__, k, None)
+                # An explicit JsonField marker means the column is raw JSON
+                # (e.g. a plugin field holding a list of dicts). Keep it as-is
+                # instead of coercing each dict into a nested Record, which
+                # would break serialize()/save() (no id on plain JSON dicts).
+                if hasattr(lookup, "_json_field"):
+                    self._add_cache((k, copy.deepcopy(v)))
+                    setattr(self, k, v)
+                    continue
                 # check if GFK
                 if len(v) and isinstance(v[0], dict) and "object_type" in v[0]:
                     v = [generic_list_parser(k, i) for i in v]

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -200,6 +200,34 @@ class RecordTestCase(unittest.TestCase):
 
         self.assertEqual(test_obj._diff(), {"rear_ports"})
 
+    def test_json_field_list_of_dicts_kept_raw(self):
+        # Regression test for issue #625: a column explicitly marked
+        # JsonField that holds a list of dicts (e.g. an arbitrary plugin
+        # JSON field) must stay as plain dicts, not be coerced into nested
+        # Records. Coercion broke serialize()/save() because the dicts have
+        # no id.
+        from pynetbox.core.response import JsonField
+
+        class PluginRecord(Record):
+            my_json_list = JsonField
+
+        test_values = {
+            "id": 123,
+            "my_json_list": [{"example": "bug"}, {"another": "value"}],
+        }
+        test_obj = PluginRecord(test_values, Mock(base_url="test"), None)
+
+        # Items remain plain dicts, not Records.
+        self.assertIsInstance(test_obj.my_json_list[0], dict)
+        self.assertEqual(test_obj.my_json_list, test_values["my_json_list"])
+
+        # serialize() round-trips the raw JSON and save() doesn't choke.
+        self.assertEqual(
+            test_obj.serialize()["my_json_list"], test_values["my_json_list"]
+        )
+        # Unchanged list produces no false-positive diff.
+        self.assertFalse(test_obj._diff())
+
     def test_dict(self):
         test_values = {
             "id": 123,


### PR DESCRIPTION
### Fixes: #625

A `JsonField`-marked column holding a list of dicts (e.g. a plugin JSON field like `[{"example": "bug"}]`) was coerced into nested `Record` objects instead of kept as raw JSON, so a later `.save()` failed reading a non-existent `id`. The marker was honored in the dict branch of `Record._parse_values` but not the list branch; this adds the same check there.

The fix is gated entirely on the `JsonField` marker, so unmarked fields are unaffected and every existing Record-wrapping path behaves as before. This avoids the fragile `"id"`-sniffing heuristic discussed on the issue.