### PR TITLE
#688: Skip network fetch for dunder attributes in Record.__getattr__

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -334,7 +334,16 @@ class Record:
 
         In order to prevent non-explicit behavior,`k='keys'` is
         excluded because casting to dict() calls this attr.
+
+        Dunder attributes are excluded as well: they are never NetBox
+        fields, and probing for them (e.g. pydantic's isinstance check
+        calling `hasattr(obj, '__pydantic_decorators__')`, or copy and
+        pickle machinery) must not trigger a network fetch that would
+        also clobber local modifications.
         """
+        if k.startswith("__") and k.endswith("__"):
+            raise AttributeError('object has no attribute "{}"'.format(k))
+
         if self.url:
             if self.has_details is False and k != "keys":
                 if self.full_details():

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -37,6 +37,24 @@ class RecordTestCase(unittest.TestCase):
         with self.assertRaises(AttributeError) as _:
             test_obj.nothing
 
+    def test_dunder_attribute_does_not_trigger_full_details(self):
+        """Probing for a missing dunder attribute (e.g. pydantic's
+        isinstance check, copy/pickle machinery) must not fire a network
+        request nor clobber local modifications. See issue #688.
+        """
+        test_values = {
+            "id": 123,
+            "url": "http://localhost:8000/api/dcim/devices/123/",
+            "name": "original",
+        }
+        test_obj = Record(test_values, Mock(base_url="http://localhost:8000/api"), None)
+        test_obj.name = "modified"
+        with patch.object(Record, "full_details") as full_details:
+            self.assertFalse(hasattr(test_obj, "__pydantic_decorators__"))
+            full_details.assert_not_called()
+        # Local modification is preserved.
+        self.assertEqual(test_obj.name, "modified")
+
     def test_dict_access(self):
         test_values = {
             "id": 123,

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -50,9 +50,18 @@ class RecordTestCase(unittest.TestCase):
         test_obj = Record(test_values, Mock(base_url="http://localhost:8000/api"), None)
         test_obj.name = "modified"
         with patch.object(Record, "full_details") as full_details:
+            # Simulate what the real full_details would do if reached:
+            # re-parse the server values and overwrite local edits.
+            def clobber():
+                test_obj.name = "original"
+                return True
+
+            full_details.side_effect = clobber
+
             self.assertFalse(hasattr(test_obj, "__pydantic_decorators__"))
             full_details.assert_not_called()
-        # Local modification is preserved.
+        # Local modification is preserved: the dunder guard short-circuited
+        # before full_details could run and clobber it.
         self.assertEqual(test_obj.name, "modified")
 
     def test_dict_access(self):


### PR DESCRIPTION
### Fixes: #688 

short-circuit dunder attributes at the top of __getattr__ — they're never NetBox fields, so they raise AttributeError immediately without any fetch. This also protects against copy.deepcopy, pickling, and other libraries that probe for dunders.