### PR TITLE
#715 - allow endpoints with underscores

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -53,6 +53,7 @@ The `App` class represents a NetBox application (such as `dcim`, `ipam`, or `cir
     options:
         members:
             - config
+            - endpoint
         show_source: true
         show_root_heading: true
         heading_level: 3

--- a/docs/custom-objects.md
+++ b/docs/custom-objects.md
@@ -54,6 +54,20 @@ new = nb.plugins.custom_objects.cidr_list.create(name="ours", prefix=42)
 
 `CustomObject.custom_object_type` resolves to a `CustomObjectTypes` record, so `obj.custom_object_type.slug` works without an extra fetch when the per-type serializer includes it.
 
+### Slugs that contain underscores
+
+Attribute access converts underscores to dashes, which is correct for almost every endpoint but breaks when an endpoint slug genuinely contains an underscore — e.g. a slug of `my_first_custom_object` would be requested as `.../custom-objects/my-first-custom-object/` and 404. Use `App.endpoint()` to pass the slug verbatim (the fix for [#715](https://github.com/netbox-community/pynetbox/issues/715)):
+
+```python
+# Attribute access — underscores become dashes:
+nb.plugins.custom_objects.my_first_custom_object        # → .../custom-objects/my-first-custom-object/
+
+# endpoint() — slug used as-is, underscores preserved:
+nb.plugins.custom_objects.endpoint("my_first_custom_object").all()   # → .../custom-objects/my_first_custom_object/
+```
+
+`endpoint()` is a per-call escape hatch: it returns an ordinary `Endpoint` (same CRUD methods, same typed `CustomObject` records) and changes nothing about the default attribute-access behaviour. It works on any `App`, not just plugins.
+
 ## Linked Objects
 
 `linked-objects/` reports which custom objects link to a given NetBox object via an Object/MultiObject field:

--- a/docs/endpoint.md
+++ b/docs/endpoint.md
@@ -19,6 +19,18 @@ filtered = devices.filter(site='headquarters')
 new_device = devices.create(name='test', site=1, device_type=1, role=1)
 ```
 
+## Slugs with underscores
+
+Attribute access converts underscores to dashes (`nb.dcim.ip_addresses` → the `ip-addresses` endpoint), since Python attribute names can't contain dashes. For the rare endpoint whose URL slug legitimately contains an underscore (e.g. some custom-objects plugin types), use `App.endpoint()` to pass the slug verbatim:
+
+```python
+# Attribute access — underscores become dashes:
+nb.plugins.custom_objects.my_object        # → .../custom-objects/my-object/
+
+# endpoint() — slug used as-is:
+nb.plugins.custom_objects.endpoint("my_object").all()   # → .../custom-objects/my_object/
+```
+
 ## Endpoint Class
 
 ::: pynetbox.core.endpoint.Endpoint

--- a/pynetbox/core/app.py
+++ b/pynetbox/core/app.py
@@ -82,6 +82,29 @@ class App:
     def __getattr__(self, name):
         return Endpoint(self.api, self, name, model=self.model)
 
+    def endpoint(self, name):
+        """Return an Endpoint using ``name`` as the literal URL slug.
+
+        Attribute access (``app.ip_addresses``) converts underscores to
+        dashes, which is correct for the vast majority of NetBox endpoints.
+        This method skips that conversion so endpoints whose slug genuinely
+        contains underscores can be reached.
+
+        ## Parameters
+
+        * **name** (str): The endpoint slug, used verbatim (no ``_`` → ``-``).
+
+        ## Returns
+        Endpoint matching the given slug.
+
+        ## Examples
+
+        ```python
+        nb.plugins.custom_objects.endpoint("my_custom_object").all()
+        ```
+        """
+        return Endpoint(self.api, self, name, model=self.model, literal_name=True)
+
     def config(self):
         """Returns config response from app.
 

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -33,6 +33,10 @@ class Endpoint:
     * **app** (App): Takes App.
     * **name** (str): Name of endpoint passed to App().
     * **model** (obj, optional): Custom model for given app.
+    * **literal_name** (bool, optional): When True, use ``name`` verbatim
+      as the URL slug instead of converting underscores to dashes. Used to
+      reach endpoints whose slug legitimately contains underscores
+      (e.g. custom objects). Defaults to False.
 
     ## Note
 
@@ -40,11 +44,16 @@ class Endpoint:
     names you should convert the dash to an underscore.
     (E.g. querying the ip-addresses endpoint is done with
     ``nb.ipam.ip_addresses.all()``.)
+
+    For the rare endpoint whose slug really does contain underscores,
+    use ``App.endpoint()`` (e.g.
+    ``nb.plugins.custom_objects.endpoint("my_custom_object")``) which sets
+    ``literal_name=True`` so no conversion is applied.
     """
 
-    def __init__(self, api, app, name, model=None):
+    def __init__(self, api, app, name, model=None, literal_name=False):
         self.return_obj = self._lookup_ret_obj(name, model)
-        self.name = name.replace("_", "-")
+        self.name = name if literal_name else name.replace("_", "-")
         self.api = api
         self.app = app
         self.base_url = api.base_url

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -56,3 +56,28 @@ class PluginAppTestCase(unittest.TestCase):
         api = pynetbox.api(host, **def_kwargs)
         test_plugin = api.plugins.test_plugin
         self.assertEqual(test_plugin.name, "plugins/test-plugin")
+
+
+class AppEndpointLiteralNameTestCase(unittest.TestCase):
+    def test_attribute_access_converts_underscores(self):
+        api = pynetbox.api(host, **def_kwargs)
+        endpoint = api.plugins.custom_objects.my_custom_object
+        self.assertEqual(endpoint.name, "my-custom-object")
+        self.assertEqual(
+            endpoint.url,
+            "{}/api/plugins/custom-objects/my-custom-object".format(host),
+        )
+
+    def test_endpoint_method_preserves_underscores(self):
+        api = pynetbox.api(host, **def_kwargs)
+        endpoint = api.plugins.custom_objects.endpoint("my_custom_object")
+        self.assertEqual(endpoint.name, "my_custom_object")
+        self.assertEqual(
+            endpoint.url,
+            "{}/api/plugins/custom-objects/my_custom_object".format(host),
+        )
+
+    def test_endpoint_method_works_on_builtin_app(self):
+        api = pynetbox.api(host, **def_kwargs)
+        endpoint = api.dcim.endpoint("device_roles")
+        self.assertEqual(endpoint.name, "device_roles")


### PR DESCRIPTION
### Fixes: #715

Adds a new App.endpoint(name) method that constructs an Endpoint using name as the literal URL slug, skipping the underscore-to-dash conversion:

```
# Attribute access — underscores become dashes (unchanged):
nb.plugins.custom_objects.my_first_custom_object        # → .../custom-objects/my-first-custom-object/

# New escape hatch — slug used verbatim:
nb.plugins.custom_objects.endpoint("my_first_custom_object").all()   # → .../custom-objects/my_first_custom_object/
```

- Opt-in and per-call — no global state, thread-safe, and zero change to existing attribute-access behavior.
- Generic — works on any App/plugin, not just custom objects, so it doesn't special-case any prefix.
- Mapping preserved — endpoint() passes the same model as attribute access, so model/return-object resolution is unchanged (e.g. you still get typed CustomObject records with the extension registered).