### PR TITLE
#748 - Stop re-sending PATCH for unchanged partial custom_fields

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -694,7 +694,9 @@ class Record:
         # field omitted from an update unchanged. Restrict the comparison to the
         # keys present in the current value so that assigning a subset of custom
         # fields isn't seen as removing the others (issue #748). To clear a
-        # custom field the caller still sets it explicitly to None.
+        # custom field the caller still sets it explicitly to None. Assigning an
+        # empty dict is therefore a no-op (it touches no keys), matching NetBox's
+        # merge semantics where an empty custom_fields body changes nothing.
         current_cf = current_serialized.get("custom_fields")
         init_cf = init_serialized.get("custom_fields")
         if isinstance(current_cf, dict) and isinstance(init_cf, dict):

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -687,9 +687,27 @@ class Record:
                 return k, ",".join(map(str, v))
             return k, v
 
-        current = Hashabledict({fmt_dict(k, v) for k, v in self.serialize().items()})
+        current_serialized = self.serialize()
+        init_serialized = self.serialize(init=True)
+
+        # custom_fields use merge semantics on PATCH: NetBox leaves any custom
+        # field omitted from an update unchanged. Restrict the comparison to the
+        # keys present in the current value so that assigning a subset of custom
+        # fields isn't seen as removing the others (issue #748). To clear a
+        # custom field the caller still sets it explicitly to None.
+        current_cf = current_serialized.get("custom_fields")
+        init_cf = init_serialized.get("custom_fields")
+        if isinstance(current_cf, dict) and isinstance(init_cf, dict):
+            init_serialized = {
+                **init_serialized,
+                "custom_fields": {
+                    k: v for k, v in init_cf.items() if k in current_cf
+                },
+            }
+
+        current = Hashabledict({fmt_dict(k, v) for k, v in current_serialized.items()})
         init = Hashabledict(
-            {fmt_dict(k, v) for k, v in self.serialize(init=True).items()}
+            {fmt_dict(k, v) for k, v in init_serialized.items()}
         )
         return set([i[0] for i in set(current.items()) ^ set(init.items())])
 

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -576,6 +576,37 @@ class RecordTestCase(unittest.TestCase):
         diff = interface._diff()
         self.assertIn("primary_mac_address", diff)
 
+    def test_diff_partial_custom_fields_no_false_change(self):
+        """Regression test for issue #748: assigning a subset of custom_fields
+        should not flag the omitted fields as changed."""
+        test_obj = Record(
+            {
+                "id": 123,
+                "name": "testsite",
+                "custom_fields": {"testfield": "val", "other_field": None},
+            },
+            None,
+            None,
+        )
+        # Re-assign only the field we care about, leaving its value unchanged.
+        test_obj.custom_fields = {"testfield": "val"}
+        self.assertFalse(test_obj._diff())
+
+    def test_diff_partial_custom_fields_detects_real_change(self):
+        """Issue #748: a changed value in a partial custom_fields assignment is
+        still detected."""
+        test_obj = Record(
+            {
+                "id": 123,
+                "name": "testsite",
+                "custom_fields": {"testfield": "val", "other_field": None},
+            },
+            None,
+            None,
+        )
+        test_obj.custom_fields = {"testfield": "new_val"}
+        self.assertEqual(test_obj._diff(), {"custom_fields"})
+
     def test_serialize_excludes_internal_attributes(self):
         """Ensure serialize() filters out internal Record metadata."""
         test_obj = Record({"id": 123, "name": "test"}, None, None)

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -607,6 +607,36 @@ class RecordTestCase(unittest.TestCase):
         test_obj.custom_fields = {"testfield": "new_val"}
         self.assertEqual(test_obj._diff(), {"custom_fields"})
 
+    def test_diff_partial_custom_fields_detects_new_key(self):
+        """Issue #748: assigning a custom field key that was not in the original
+        response is detected as a change."""
+        test_obj = Record(
+            {
+                "id": 123,
+                "name": "testsite",
+                "custom_fields": {"testfield": "val", "other_field": None},
+            },
+            None,
+            None,
+        )
+        test_obj.custom_fields = {"brand_new_key": "val"}
+        self.assertEqual(test_obj._diff(), {"custom_fields"})
+
+    def test_diff_partial_custom_fields_detects_explicit_none_clear(self):
+        """Issue #748: explicitly setting a custom field to None to clear it is
+        detected as a change."""
+        test_obj = Record(
+            {
+                "id": 123,
+                "name": "testsite",
+                "custom_fields": {"testfield": "val", "other_field": None},
+            },
+            None,
+            None,
+        )
+        test_obj.custom_fields = {"testfield": None}
+        self.assertEqual(test_obj._diff(), {"custom_fields"})
+
     def test_serialize_excludes_internal_attributes(self):
         """Ensure serialize() filters out internal Record metadata."""
         test_obj = Record({"id": 123, "name": "test"}, None, None)


### PR DESCRIPTION
### Fixes: #748 

update()/save() issued a redundant PATCH (returning True) whenever a subset of an object's custom fields was passed with unchanged values - only visible when the object had more than one custom field defined. 

NetBox uses merge semantics for custom-field PATCHes (omitted keys are left untouched), but _diff() compared the full custom_fields dicts, so a partial assignment dropped the other keys and was wrongly flagged as changed. 

This change restricts the custom_fields comparison in _diff() to keys present in the new value; real value changes, new keys, and explicit None clears are still detected. Adds regression tests for the no-op and real-change cases.