### PR TITLE
#633 - Support custom thread pool executor and configurable max_workers

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -53,6 +53,61 @@ devices = list(nb_threaded.dcim.devices.all())
 print(f"With threading: {time.time() - start:.2f}s")
 ```
 
+### Tuning the Worker Count
+
+By default, threaded queries use up to 4 worker threads. Override this with `max_workers`:
+
+```python
+nb = pynetbox.api(
+    'http://localhost:8000',
+    token='your-token',
+    threading=True,
+    max_workers=8,
+)
+```
+
+### Custom Thread Pool Executor
+
+By default pynetbox builds its pool with `concurrent.futures.ThreadPoolExecutor`. You can
+inject your own executor with `thread_pool_executor`. It must be a callable matching the
+`ThreadPoolExecutor(max_workers=...)` signature and support the context-manager protocol —
+a `ThreadPoolExecutor` subclass is the simplest option.
+
+This is useful when worker threads need thread-local state that the standard executor does
+not propagate, such as an OpenTelemetry trace context, a request-scoped logging correlation
+ID, or a thread-bound database/session handle. Without propagation, work performed in the
+pool's threads is detached from the context of the calling thread.
+
+```python
+import concurrent.futures
+from opentelemetry import context as otel_context
+
+class ContextPropagatingExecutor(concurrent.futures.ThreadPoolExecutor):
+    """Carries the caller's OpenTelemetry context into each worker thread."""
+
+    def submit(self, fn, *args, **kwargs):
+        ctx = otel_context.get_current()
+
+        def run_with_context():
+            token = otel_context.attach(ctx)
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                otel_context.detach(token)
+
+        return super().submit(run_with_context)
+
+nb = pynetbox.api(
+    'http://localhost:8000',
+    token='your-token',
+    threading=True,
+    thread_pool_executor=ContextPropagatingExecutor,
+)
+```
+
+The executor is constructed once per threaded query and shut down when that query's pages
+have been fetched, so pass the class (or a factory), not an already-instantiated pool.
+
 ## Filter Validation
 
 NetBox does not validate filter parameters passed to list endpoints. An unrecognized parameter is silently ignored, which means a typo in a `.filter()` or `.get()` call can quietly return the entire table.

--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -103,11 +103,19 @@ class Api:
             thread_pool_executor (callable, optional): A `concurrent.futures.ThreadPoolExecutor` class, or any callable matching its `(max_workers=...)` signature and context-manager protocol, used to build the pool for threaded requests. Defaults to `concurrent.futures.ThreadPoolExecutor`.
             max_workers (int, optional): Maximum number of worker threads used for threaded requests, defaults to 4.
         """
+        if max_workers <= 0:
+            raise ValueError("max_workers must be a positive integer")
+
         base_url = "{}/api".format(url if url[-1] != "/" else url[:-1])
         self.token = token
         self.base_url = base_url
         self.http_session = requests.Session()
         self.threading = threading
+        # Stored as ``None`` (the sentinel) when the caller did not supply a
+        # custom executor, so ``None`` distinguishes "use the default" from an
+        # explicit choice. ``Request`` resolves ``None`` to
+        # ``concurrent.futures.ThreadPoolExecutor`` at request time, so the
+        # value here is not necessarily the executor actually used.
         self.thread_pool_executor = thread_pool_executor
         self.max_workers = max_workers
         self.strict_filters = strict_filters

--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -57,6 +57,13 @@ class Api:
     * **url** (str): The base URL to the instance of NetBox you wish to connect to.
     * **token** (str): Your NetBox token.
     * **threading** (bool, optional): Set to True to use threading in `.all()` and `.filter()` requests.
+    * **thread_pool_executor** (callable, optional): A `concurrent.futures.ThreadPoolExecutor`
+      class (or any callable matching its `(max_workers=...)` signature and context-manager
+      protocol) used to build the pool for threaded requests. Defaults to
+      `concurrent.futures.ThreadPoolExecutor`. Inject a custom executor to propagate
+      thread-local state such as OpenTelemetry trace context into worker threads.
+    * **max_workers** (int, optional): Maximum number of worker threads used for threaded
+      `.all()` and `.filter()` requests. Defaults to 4. Only used when `threading=True`.
 
     ## Raises
 
@@ -82,6 +89,8 @@ class Api:
         threading=False,
         strict_filters=False,
         extensions=None,
+        thread_pool_executor=None,
+        max_workers=4,
     ):
         """Initialize the API client.
 
@@ -91,12 +100,16 @@ class Api:
             threading (bool, optional): Set to True to use threading in `.all()` and `.filter()` requests, defaults to False.
             strict_filters (bool, optional): Set to True to check GET call filters against OpenAPI specifications (intentionally not done in NetBox API), defaults to False.
             extensions (list, optional): A list of `Extension` classes or instances that register custom `Record` subclasses and content-type mappings for NetBox plugins. See `pynetbox.core.extension`.
+            thread_pool_executor (callable, optional): A `concurrent.futures.ThreadPoolExecutor` class, or any callable matching its `(max_workers=...)` signature and context-manager protocol, used to build the pool for threaded requests. Defaults to `concurrent.futures.ThreadPoolExecutor`.
+            max_workers (int, optional): Maximum number of worker threads used for threaded requests, defaults to 4.
         """
         base_url = "{}/api".format(url if url[-1] != "/" else url[:-1])
         self.token = token
         self.base_url = base_url
         self.http_session = requests.Session()
         self.threading = threading
+        self.thread_pool_executor = thread_pool_executor
+        self.max_workers = max_workers
         self.strict_filters = strict_filters
 
         self._register_extensions(extensions or [])

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -177,6 +177,8 @@ class Endpoint:
             token=self.token,
             http_session=self.api.http_session,
             threading=self.api.threading,
+            thread_pool_executor=self.api.thread_pool_executor,
+            max_workers=self.api.max_workers,
             limit=limit,
             offset=offset,
         )
@@ -352,6 +354,8 @@ class Endpoint:
             token=self.token,
             http_session=self.api.http_session,
             threading=self.api.threading,
+            thread_pool_executor=self.api.thread_pool_executor,
+            max_workers=self.api.max_workers,
             limit=limit,
             offset=offset,
         )

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -223,6 +223,8 @@ class Request:
         key=None,
         token=None,
         threading=False,
+        thread_pool_executor=None,
+        max_workers=4,
         expect_json=True,
     ):
         """Instantiates a new Request object.
@@ -253,6 +255,8 @@ class Request:
         self.http_session = http_session
         self.url = self.base if not key else "{}{}/".format(self.base, key)
         self.threading = threading
+        self.thread_pool_executor = thread_pool_executor or cf.ThreadPoolExecutor
+        self.max_workers = max_workers
         self.limit = limit
         self.offset = offset
         self.expect_json = expect_json
@@ -413,7 +417,7 @@ class Request:
 
     def concurrent_get(self, ret, page_size, page_offsets):
         futures_to_results = []
-        with cf.ThreadPoolExecutor(max_workers=4) as pool:
+        with self.thread_pool_executor(max_workers=self.max_workers) as pool:
             for offset in page_offsets:
                 new_params = {"offset": offset, "limit": page_size}
                 futures_to_results.append(

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -255,7 +255,11 @@ class Request:
         self.http_session = http_session
         self.url = self.base if not key else "{}{}/".format(self.base, key)
         self.threading = threading
-        self.thread_pool_executor = thread_pool_executor or cf.ThreadPoolExecutor
+        self.thread_pool_executor = (
+            thread_pool_executor
+            if thread_pool_executor is not None
+            else cf.ThreadPoolExecutor
+        )
         self.max_workers = max_workers
         self.limit = limit
         self.offset = offset

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -62,6 +62,12 @@ class ApiThreadPoolTestCase(unittest.TestCase):
         self.assertEqual(api.max_workers, 12)
 
     @patch("requests.sessions.Session.post", return_value=Response())
+    def test_threadpool_invalid_max_workers(self, *_):
+        for invalid in (0, -1):
+            with self.assertRaises(ValueError):
+                pynetbox.api(host, max_workers=invalid, **def_kwargs)
+
+    @patch("requests.sessions.Session.post", return_value=Response())
     @patch("pynetbox.core.endpoint.Request")
     def test_threadpool_propagated_to_request(self, request_mock, *_):
         executor = concurrent.futures.ThreadPoolExecutor

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
+import concurrent.futures
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pynetbox
 
@@ -39,6 +40,47 @@ class ApiTestCase(unittest.TestCase):
         api = pynetbox.api("http://localhost:8000/", **def_kwargs)
         self.assertTrue(api)
         self.assertEqual(api.base_url, "http://localhost:8000/api")
+
+
+class ApiThreadPoolTestCase(unittest.TestCase):
+    @patch("requests.sessions.Session.post", return_value=Response())
+    def test_threadpool_defaults(self, *_):
+        api = pynetbox.api(host, **def_kwargs)
+        self.assertIsNone(api.thread_pool_executor)
+        self.assertEqual(api.max_workers, 4)
+
+    @patch("requests.sessions.Session.post", return_value=Response())
+    def test_threadpool_custom_values_stored(self, *_):
+        executor = concurrent.futures.ThreadPoolExecutor
+        api = pynetbox.api(
+            host,
+            thread_pool_executor=executor,
+            max_workers=12,
+            **def_kwargs,
+        )
+        self.assertIs(api.thread_pool_executor, executor)
+        self.assertEqual(api.max_workers, 12)
+
+    @patch("requests.sessions.Session.post", return_value=Response())
+    @patch("pynetbox.core.endpoint.Request")
+    def test_threadpool_propagated_to_request(self, request_mock, *_):
+        executor = concurrent.futures.ThreadPoolExecutor
+        api = pynetbox.api(
+            host,
+            threading=True,
+            thread_pool_executor=executor,
+            max_workers=9,
+            **def_kwargs,
+        )
+        # Avoid iterating the mocked RecordSet; we only care about the kwargs
+        # passed into the Request that backs .all().
+        request_mock.return_value = Mock()
+        api.dcim.devices.all()
+
+        _, kwargs = request_mock.call_args
+        self.assertIs(kwargs["thread_pool_executor"], executor)
+        self.assertEqual(kwargs["max_workers"], 9)
+        self.assertTrue(kwargs["threading"])
 
 
 class ApiVersionTestCase(unittest.TestCase):

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import unittest
 from unittest.mock import Mock
 
@@ -69,6 +70,59 @@ class RequestTestCase(unittest.TestCase):
             params={"offset": 20, "limit": 10},
             headers={"accept": "application/json"},
             json=None,
+        )
+
+
+class ConcurrentGetTestCase(unittest.TestCase):
+    """Tests for the threaded pagination executor wiring."""
+
+    def _request(self, **kwargs):
+        test_obj = Request(
+            http_session=Mock(),
+            base="http://localhost:8001/api/dcim/devices",
+            **kwargs,
+        )
+        # Stub the per-page HTTP call so concurrent_get has something to fan out.
+        test_obj._make_call = Mock(return_value={"results": [1, 2]})
+        return test_obj
+
+    def test_defaults_to_threadpoolexecutor(self):
+        """Without an override, the stdlib ThreadPoolExecutor is used."""
+        test_obj = self._request()
+        self.assertIs(
+            test_obj.thread_pool_executor, concurrent.futures.ThreadPoolExecutor
+        )
+        self.assertEqual(test_obj.max_workers, 4)
+
+    def test_custom_executor_is_used(self):
+        """A custom executor factory is invoked with the configured max_workers."""
+        calls = {}
+
+        class RecordingExecutor(concurrent.futures.ThreadPoolExecutor):
+            def __init__(self, max_workers=None):
+                calls["max_workers"] = max_workers
+                calls["used"] = True
+                super().__init__(max_workers=max_workers)
+
+        test_obj = self._request(
+            thread_pool_executor=RecordingExecutor,
+            max_workers=7,
+        )
+
+        ret = []
+        test_obj.concurrent_get(ret, page_size=2, page_offsets=[2, 4, 6])
+
+        self.assertTrue(calls.get("used"))
+        self.assertEqual(calls["max_workers"], 7)
+        # Three offsets, two results per page.
+        self.assertEqual(len(ret), 6)
+        self.assertEqual(test_obj._make_call.call_count, 3)
+
+    def test_none_executor_falls_back_to_default(self):
+        """Passing None explicitly resolves to the stdlib default."""
+        test_obj = self._request(thread_pool_executor=None)
+        self.assertIs(
+            test_obj.thread_pool_executor, concurrent.futures.ThreadPoolExecutor
         )
 
 


### PR DESCRIPTION
### Fixes: #633

Adds two optional, backward-compatible parameters to `Api()` that let callers control how threaded `.all()` / `.filter()` queries fetch pages:

- **`thread_pool_executor`** - a `ThreadPoolExecutor` class or factory used to build the pool. Defaults to the stdlib `concurrent.futures.ThreadPoolExecutor`.
- **`max_workers`** - exposes the previously hardcoded worker count (`4`).

## Motivation

The stdlib `ThreadPoolExecutor` does not propagate the calling thread's `contextvars` / thread-locals into worker threads, so anything relying on that breaks silently when `threading=True`: OpenTelemetry/distributed traces detach, structured-logging correlation IDs vanish, and APM instrumentation misses the threaded work. Injecting a context-aware executor fixes this. Exposing `max_workers` also lets users tune concurrency for their NetBox instance.

## Changes

- `core/api.py` - accept and store `thread_pool_executor` and `max_workers`.
- `core/endpoint.py` - pass both into the `Request` built by `.all()` / `.filter()`.
- `core/query.py` - `concurrent_get` now uses `self.thread_pool_executor(max_workers=self.max_workers)` instead of a hardcoded `ThreadPoolExecutor(max_workers=4)`.

## Compatibility

Fully backward compatible - defaults reproduce today's exact behavior. Only the `threading=True` page-fetching path is affected.

## Tests & docs

- Unit tests for default resolution, custom executor invocation with the configured `max_workers`, and propagation from `Api` into `Request`.
- `docs/advanced.md`: new sections on tuning worker count and supplying a custom executor (with an OpenTelemetry context-propagation example).
