### PR TITLE
#764 - Support cursor-based pagination from NetBox 4.6

### DIFF
--- a/.github/workflows/py3.yml
+++ b/.github/workflows/py3.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.12", "3.13", "3.14"]
-        netbox: ["4.3", "4.4", "4.5"]
+        netbox: ["4.4", "4.5", "4.6"]
 
     steps:
       - name: Checkout pynetbox

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -53,6 +53,54 @@ devices = list(nb_threaded.dcim.devices.all())
 print(f"With threading: {time.time() - start:.2f}s")
 ```
 
+## Cursor-Based Pagination
+
+Starting with NetBox 4.6, the REST API supports cursor-based pagination as an
+alternative to the default offset-based pagination. Instead of skipping a
+growing number of rows with an `offset`, the server pages forward using the
+primary key (`id`) as a cursor. This avoids the cost of scanning the table up to
+the offset position, so it performs significantly better on very large result
+sets.
+
+### Enabling Cursor Pagination
+
+Pass `pagination="cursor"` when constructing the API client:
+
+```python
+import pynetbox
+
+nb = pynetbox.api(
+    'http://localhost:8000',
+    token='your-token',
+    pagination="cursor",
+)
+
+# .all() and .filter() now page using the server's `start` cursor
+devices = nb.dcim.devices.all()
+```
+
+pynetbox probes the NetBox version once on the first query. If the server is
+older than 4.6 (and therefore does not support cursor pagination), it
+transparently falls back to offset-based pagination, so it is safe to leave this
+option enabled across mixed environments.
+
+### Trade-offs
+
+!!! note "Things to know about cursor pagination"
+    - **No total count up front.** NetBox omits the `count` in cursor mode for
+      performance. pynetbox still supports `len(record_set)`, but doing so
+      triggers a separate count request.
+    - **Fixed ordering.** Results are always ordered by `id`; an explicit
+      `ordering` filter cannot be combined with cursor pagination.
+    - **Not combined with threading.** Cursor pagination is inherently
+      sequential (each page's cursor depends on the previous page), so it cannot
+      be parallelized. When `pagination="cursor"` is set, queries page
+      sequentially even if `threading=True`. For parallel fetching of large
+      offset-paginated result sets, use threading instead (see above).
+    - **Explicit `offset` still works.** Passing an explicit `offset` to
+      `.all()`/`.filter()` requests a single offset-based page as before, since
+      `start` and `offset` are mutually exclusive on the server.
+
 ## Filter Validation
 
 NetBox does not validate filter parameters passed to list endpoints. An unrecognized parameter is silently ignored, which means a typo in a `.filter()` or `.get()` call can quietly return the entire table.

--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -255,10 +255,16 @@ class Api:
                 # be parallelised; the cursor path ignores self.threading.
                 # Warn so the no-op threading configuration is not a silent
                 # performance surprise.
+                # stacklevel=5 attributes the warning to the caller's list
+                # request rather than to pynetbox internals. The version probe
+                # is resolved lazily on the first page fetch, so the fixed
+                # frame chain at this point is:
+                #   _effective_pagination -> Request._resolve_pagination
+                #   -> Request.get -> RecordSet.__next__/__len__ -> caller.
                 warnings.warn(
                     "threading=True has no effect with cursor pagination; "
                     "cursor pages are fetched sequentially.",
-                    stacklevel=2,
+                    stacklevel=5,
                 )
         return "cursor" if self._cursor_supported else "offset"
 

--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import contextlib
+import warnings
 
 import requests
 from packaging import version
@@ -220,8 +221,24 @@ class Api:
                 self._cursor_supported = version.parse(self.version) >= version.parse(
                     "4.6"
                 )
-            except (RequestError, InvalidVersion):
+            except (RequestError, InvalidVersion, requests.exceptions.RequestException):
+                # RequestError covers a non-ok HTTP response from the version
+                # probe; requests.exceptions.RequestException covers transport
+                # failures (ConnectionError, Timeout, ...) raised before a
+                # response exists. In every case fall back to offset, as the
+                # docstring promises, and let the real list request surface any
+                # underlying connectivity error.
                 self._cursor_supported = False
+            if self._cursor_supported and self.threading:
+                # Cursor pagination follows next links sequentially and cannot
+                # be parallelised; the cursor path ignores self.threading.
+                # Warn so the no-op threading configuration is not a silent
+                # performance surprise.
+                warnings.warn(
+                    "threading=True has no effect with cursor pagination; "
+                    "cursor pages are fetched sequentially.",
+                    stacklevel=2,
+                )
         return "cursor" if self._cursor_supported else "offset"
 
     def openapi(self):

--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -17,9 +17,11 @@ limitations under the License.
 import contextlib
 
 import requests
+from packaging import version
+from packaging.version import InvalidVersion
 
 from pynetbox.core.app import App, PluginsApp
-from pynetbox.core.query import Request, TOKEN_PREFIX
+from pynetbox.core.query import Request, RequestError, TOKEN_PREFIX
 from pynetbox.core.response import Record
 from pynetbox.models.mapper import CONTENT_TYPE_MAPPER
 
@@ -82,6 +84,7 @@ class Api:
         threading=False,
         strict_filters=False,
         extensions=None,
+        pagination="offset",
     ):
         """Initialize the API client.
 
@@ -91,13 +94,20 @@ class Api:
             threading (bool, optional): Set to True to use threading in `.all()` and `.filter()` requests, defaults to False.
             strict_filters (bool, optional): Set to True to check GET call filters against OpenAPI specifications (intentionally not done in NetBox API), defaults to False.
             extensions (list, optional): A list of `Extension` classes or instances that register custom `Record` subclasses and content-type mappings for NetBox plugins. See `pynetbox.core.extension`.
+            pagination (str, optional): Pagination strategy for `.all()` and `.filter()`, either `"offset"` (default) or `"cursor"`. Cursor pagination (NetBox 4.6+) offers better performance on very large result sets but omits the total count and cannot be combined with threading or `ordering`. On NetBox versions older than 4.6 it transparently falls back to offset pagination.
         """
+        if pagination not in ("offset", "cursor"):
+            raise ValueError(
+                "pagination must be 'offset' or 'cursor', got {!r}".format(pagination)
+            )
         base_url = "{}/api".format(url if url[-1] != "/" else url[:-1])
         self.token = token
         self.base_url = base_url
         self.http_session = requests.Session()
         self.threading = threading
         self.strict_filters = strict_filters
+        self.pagination = pagination
+        self._cursor_supported = None
 
         self._register_extensions(extensions or [])
 
@@ -193,6 +203,26 @@ class Api:
             http_session=self.http_session,
         ).get_version()
         return version
+
+    def _effective_pagination(self):
+        """Resolve the pagination strategy to use for list requests.
+
+        Returns ``"cursor"`` only when cursor pagination was requested *and*
+        the connected NetBox supports it (4.6+). Otherwise returns
+        ``"offset"``. The server version is probed once and cached, so only
+        the first `.all()`/`.filter()` on a cursor-mode `Api` pays the cost;
+        offset-mode instances never make the extra request.
+        """
+        if self.pagination != "cursor":
+            return "offset"
+        if self._cursor_supported is None:
+            try:
+                self._cursor_supported = version.parse(self.version) >= version.parse(
+                    "4.6"
+                )
+            except (RequestError, InvalidVersion):
+                self._cursor_supported = False
+        return "cursor" if self._cursor_supported else "offset"
 
     def openapi(self):
         """Returns the OpenAPI spec.

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -179,6 +179,7 @@ class Endpoint:
             threading=self.api.threading,
             limit=limit,
             offset=offset,
+            pagination=self.api._effective_pagination(),
         )
 
         return RecordSet(self, req)
@@ -354,6 +355,7 @@ class Endpoint:
             threading=self.api.threading,
             limit=limit,
             offset=offset,
+            pagination=self.api._effective_pagination(),
         )
 
         return RecordSet(self, req)

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -190,7 +190,10 @@ class Endpoint:
             max_workers=self.api.max_workers,
             limit=limit,
             offset=offset,
-            pagination=self.api._effective_pagination(),
+            # Passed uncalled so the version probe behind
+            # _effective_pagination() is deferred until the request actually
+            # runs, rather than firing when this lazy RecordSet is built.
+            pagination=self.api._effective_pagination,
         )
 
         return RecordSet(self, req)
@@ -368,7 +371,10 @@ class Endpoint:
             max_workers=self.api.max_workers,
             limit=limit,
             offset=offset,
-            pagination=self.api._effective_pagination(),
+            # Passed uncalled so the version probe behind
+            # _effective_pagination() is deferred until the request actually
+            # runs, rather than firing when this lazy RecordSet is built.
+            pagination=self.api._effective_pagination,
         )
 
         return RecordSet(self, req)

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -224,6 +224,7 @@ class Request:
         token=None,
         threading=False,
         expect_json=True,
+        pagination="offset",
     ):
         """Instantiates a new Request object.
 
@@ -238,6 +239,11 @@ class Request:
         * **expect_json** (bool, optional): If True, expects JSON response
             and sets appropriate Accept header. If False, expects raw content
             (e.g., SVG, XML) and returns text. Defaults to True.
+        * **pagination** (str, optional): Pagination strategy for list
+            views, either ``"offset"`` (default) or ``"cursor"``. Cursor
+            pagination (NetBox 4.6+) pages with the ``start`` parameter and
+            follows ``next`` links sequentially; it omits the total count
+            and is mutually exclusive with threading.
 
         ## Note
 
@@ -256,6 +262,7 @@ class Request:
         self.limit = limit
         self.offset = offset
         self.expect_json = expect_json
+        self.pagination = pagination
 
     def get_openapi(self):
         """Gets the OpenAPI Spec."""
@@ -438,15 +445,39 @@ class Request:
         * ContentError if response is not json.
         """
 
+        # Cursor-based pagination (NetBox 4.6+) is used only for full
+        # iteration of a list view. An explicit offset (single requested
+        # page) or a detail route (add_params already set) falls back to
+        # the default offset behavior, since 'start' and 'offset' are
+        # mutually exclusive on the server.
+        use_cursor = (
+            self.pagination == "cursor"
+            and self.offset is None
+            and add_params is None
+        )
+
         if not add_params and self.limit is not None:
             add_params = {"limit": self.limit}
-            if self.limit and self.offset is not None:
+            if use_cursor:
+                # 'start' is the numeric id of the first object to return;
+                # begin at the start and follow the server's next links.
+                add_params["start"] = 0
+            elif self.limit and self.offset is not None:
                 # if non-zero limit and some offset -> add offset
                 add_params["offset"] = self.offset
         req = self._make_call(add_params=add_params)
         if isinstance(req, dict) and req.get("results") is not None:
+            # In cursor mode NetBox omits the count (returns null); it is
+            # fetched lazily by get_count() if len() is requested.
             self.count = req["count"]
-            if self.offset is not None:
+            if use_cursor:
+                # Sequentially follow next links; each link carries the
+                # next 'start' cursor (last pk + 1) computed by the server.
+                yield from req["results"]
+                while req.get("next"):
+                    req = self._make_call(url_override=req["next"])
+                    yield from req["results"]
+            elif self.offset is not None:
                 # only yield requested page results if paginating
                 for i in req["results"]:
                     yield i
@@ -595,6 +626,10 @@ class Request:
         * ContentError if response is not json.
         """
 
-        if not hasattr(self, "count"):
+        # ``count`` may be unset, or set to None when cursor pagination was
+        # used (NetBox omits the count in that mode). In both cases fetch it
+        # explicitly. This uses an offset-style request (no 'start' param),
+        # which always returns the total count.
+        if getattr(self, "count", None) is None:
             self.count = self._make_call(add_params={"limit": 1, "brief": 1})["count"]
         return self.count

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -241,10 +241,13 @@ class Request:
         * **expect_json** (bool, optional): If True, expects JSON response
             and sets appropriate Accept header. If False, expects raw content
             (e.g., SVG, XML) and returns text. Defaults to True.
-        * **pagination** (str, optional): Pagination strategy for list
-            views, either ``"offset"`` (default) or ``"cursor"``. Cursor
-            pagination (NetBox 4.6+) pages with the ``start`` parameter and
-            follows ``next`` links sequentially; it omits the total count
+        * **pagination** (str or callable, optional): Pagination strategy for
+            list views, either ``"offset"`` (default) or ``"cursor"``. May
+            also be a zero-argument callable returning one of those strings,
+            which is resolved lazily on the first list request so any work it
+            performs (e.g. a server version probe) is deferred until needed.
+            Cursor pagination (NetBox 4.6+) pages with the ``start`` parameter
+            and follows ``next`` links sequentially; it omits the total count
             and is mutually exclusive with threading.
 
         ## Note
@@ -439,6 +442,18 @@ class Request:
                 result = future.result()
                 ret.extend(result["results"])
 
+    def _resolve_pagination(self):
+        """Resolve the configured pagination strategy.
+
+        ``pagination`` may be either a string (``"offset"``/``"cursor"``) or a
+        zero-argument callable returning one. Deferring the call to here keeps
+        any work it does (such as the NetBox version probe behind
+        ``Api._effective_pagination``) out of ``Request`` construction, so a
+        lazily-built ``RecordSet`` that is never iterated makes no extra call.
+        """
+        pagination = self.pagination
+        return pagination() if callable(pagination) else pagination
+
     def get(self, add_params=None):
         """Makes a GET request.
 
@@ -459,7 +474,7 @@ class Request:
         # the default offset behavior, since 'start' and 'offset' are
         # mutually exclusive on the server.
         use_cursor = (
-            self.pagination == "cursor"
+            self._resolve_pagination() == "cursor"
             and self.offset is None
             and add_params is None
         )

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -18,6 +18,7 @@ import concurrent.futures as cf
 import io
 import os
 import json
+import warnings
 
 from packaging import version
 
@@ -478,6 +479,19 @@ class Request:
             and self.offset is None
             and add_params is None
         )
+
+        if use_cursor and self.filters and "ordering" in self.filters:
+            # Cursor pagination derives the page boundaries from a fixed
+            # server-side ordering, so a caller-supplied 'ordering' filter is
+            # silently ignored by NetBox. Warn rather than let the result come
+            # back in an unexpected order.
+            # stacklevel=3: get() (generator body, resumed on the first
+            # next()) -> RecordSet.__next__/__len__ -> caller.
+            warnings.warn(
+                "ordering has no effect with cursor pagination; results are "
+                "returned in NetBox's fixed cursor order.",
+                stacklevel=3,
+            )
 
         if not add_params and self.limit is not None:
             add_params = {"limit": self.limit}

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -136,13 +136,18 @@ class RecordSet:
 
     def __len__(self):
         try:
-            return self.request.count
+            count = self.request.count
         except AttributeError:
             try:
                 self._response_cache.append(next(self.response))
             except StopIteration:
                 return 0
-            return self.request.count
+            count = self.request.count
+        if count is None:
+            # Cursor-based pagination omits the total count; fetch it
+            # explicitly with a separate (offset-based) count request.
+            count = self.request.get_count()
+        return count
 
     def update(self, **kwargs):
         """Updates kwargs onto all Records in the RecordSet and saves these.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -34,6 +34,8 @@ def get_netbox_docker_version_tag(netbox_version):
         tag = "3.4.2"
     elif (major, minor) == (4, 5):
         tag = "4.0.2"
+    elif (major, minor) == (4, 6):
+        tag = "5.0.1"
     else:
         raise NotImplementedError(
             "Version %s is not currently supported" % netbox_version

--- a/tests/integration/test_pagination.py
+++ b/tests/integration/test_pagination.py
@@ -1,3 +1,5 @@
+import contextlib
+
 import pytest
 from packaging import version
 
@@ -10,6 +12,26 @@ def cursor_api(docker_netbox_service):
     nb = pynetbox.api(docker_netbox_service["url"], pagination="cursor")
     nb.create_token("admin", "admin")
     return nb
+
+
+@contextlib.contextmanager
+def capture_request_urls(api):
+    """Record the URL of every request issued through ``api``'s session.
+
+    Uses a ``requests`` response hook so the assertions can inspect exactly
+    which query parameters were sent, rather than only the deserialized
+    results (which look identical regardless of the pagination strategy used).
+    """
+    urls = []
+
+    def _hook(response, *args, **kwargs):
+        urls.append(response.request.url)
+
+    api.http_session.hooks["response"].append(_hook)
+    try:
+        yield urls
+    finally:
+        api.http_session.hooks["response"].remove(_hook)
 
 
 @pytest.fixture(scope="module")
@@ -42,7 +64,14 @@ class TestCursorPagination:
 
         # Force a small page size so the result set spans multiple cursor
         # pages and the next-link following is actually exercised.
-        results = list(cursor_api.ipam.prefixes.filter(limit=2))
+        with capture_request_urls(cursor_api) as urls:
+            results = list(cursor_api.ipam.prefixes.filter(limit=2))
+
+        # Assert cursor pagination is genuinely in play: the offset strategy
+        # never emits a 'start' parameter, so its presence proves the client
+        # took the cursor path rather than silently falling back to offset.
+        assert any("start=" in url for url in urls)
+
         returned = {str(p.prefix) for p in results}
         for prefix in prefixes:
             assert str(prefix.prefix) in returned
@@ -53,4 +82,10 @@ class TestCursorPagination:
             pytest.skip("cursor pagination requires NetBox 4.6+")
 
         record_set = cursor_api.ipam.prefixes.filter(limit=2)
-        assert len(record_set) >= len(prefixes)
+        with capture_request_urls(cursor_api) as urls:
+            count = len(record_set)
+
+        assert count >= len(prefixes)
+        # len() fetches the first cursor page (start=0) before refetching the
+        # count, so confirm the cursor path was exercised here too.
+        assert any("start=" in url for url in urls)

--- a/tests/integration/test_pagination.py
+++ b/tests/integration/test_pagination.py
@@ -1,0 +1,56 @@
+import pytest
+from packaging import version
+
+import pynetbox
+
+
+@pytest.fixture(scope="module")
+def cursor_api(docker_netbox_service):
+    """An Api instance configured for cursor pagination (NetBox 4.6+)."""
+    nb = pynetbox.api(docker_netbox_service["url"], pagination="cursor")
+    nb.create_token("admin", "admin")
+    return nb
+
+
+@pytest.fixture(scope="module")
+def prefixes(api):
+    """Create enough prefixes to span more than one cursor page."""
+    created = [
+        api.ipam.prefixes.create(prefix="198.51.100.{}/32".format(i))
+        for i in range(5)
+    ]
+    yield created
+    for prefix in created:
+        prefix.delete()
+
+
+class TestCursorPagination:
+    def test_cursor_pagination_returns_all_objects(
+        self, cursor_api, nb_version, prefixes
+    ):
+        """Cursor pagination walks every page and yields all objects.
+
+        Gated to NetBox 4.6+, where cursor pagination is available. On older
+        versions the client transparently falls back to offset pagination, so
+        this end-to-end check of the ``start`` semantics and ``next`` link
+        following is only meaningful from 4.6 onward.
+        """
+        if nb_version < version.parse("4.6"):
+            pytest.skip("cursor pagination requires NetBox 4.6+")
+
+        assert cursor_api._effective_pagination() == "cursor"
+
+        # Force a small page size so the result set spans multiple cursor
+        # pages and the next-link following is actually exercised.
+        results = list(cursor_api.ipam.prefixes.filter(limit=2))
+        returned = {str(p.prefix) for p in results}
+        for prefix in prefixes:
+            assert str(prefix.prefix) in returned
+
+    def test_cursor_pagination_count(self, cursor_api, nb_version, prefixes):
+        """len() on a cursor RecordSet refetches the count NetBox omits."""
+        if nb_version < version.parse("4.6"):
+            pytest.skip("cursor pagination requires NetBox 4.6+")
+
+        record_set = cursor_api.ipam.prefixes.filter(limit=2)
+        assert len(record_set) >= len(prefixes)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -71,6 +71,47 @@ class ApiVersionTestCase(unittest.TestCase):
         self.assertEqual(api.version, "")
 
 
+class ApiPaginationTestCase(unittest.TestCase):
+    class ResponseHeadersWithVersion:
+        def __init__(self, version):
+            self.headers = {"API-Version": version}
+            self.ok = True
+
+    def test_invalid_pagination_rejected(self):
+        with self.assertRaises(ValueError):
+            pynetbox.api(host, pagination="bogus")
+
+    def test_default_pagination_is_offset(self):
+        api = pynetbox.api(host)
+        self.assertEqual(api.pagination, "offset")
+
+    @patch("requests.sessions.Session.get")
+    def test_effective_pagination_offset_no_version_request(self, mock_get):
+        """Offset mode must not probe the server version."""
+        api = pynetbox.api(host)
+        self.assertEqual(api._effective_pagination(), "offset")
+        mock_get.assert_not_called()
+
+    def test_effective_pagination_cursor_supported(self):
+        api = pynetbox.api(host, pagination="cursor")
+        with patch(
+            "requests.sessions.Session.get",
+            return_value=self.ResponseHeadersWithVersion("4.6"),
+        ) as mock_get:
+            self.assertEqual(api._effective_pagination(), "cursor")
+            # Result is cached; a second call does not re-probe.
+            self.assertEqual(api._effective_pagination(), "cursor")
+            self.assertEqual(mock_get.call_count, 1)
+
+    def test_effective_pagination_cursor_unsupported_falls_back(self):
+        api = pynetbox.api(host, pagination="cursor")
+        with patch(
+            "requests.sessions.Session.get",
+            return_value=self.ResponseHeadersWithVersion("4.5"),
+        ):
+            self.assertEqual(api._effective_pagination(), "offset")
+
+
 class ApiStatusTestCase(unittest.TestCase):
     class ResponseWithStatus:
         ok = True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import patch
 
+import requests
+
 import pynetbox
 
 from .util import Response
@@ -110,6 +112,38 @@ class ApiPaginationTestCase(unittest.TestCase):
             return_value=self.ResponseHeadersWithVersion("4.5"),
         ):
             self.assertEqual(api._effective_pagination(), "offset")
+
+    def test_effective_pagination_cursor_network_error_falls_back(self):
+        """A transport-level failure in the version probe falls back to offset."""
+        api = pynetbox.api(host, pagination="cursor")
+        with patch(
+            "requests.sessions.Session.get",
+            side_effect=requests.exceptions.ConnectionError("boom"),
+        ):
+            self.assertEqual(api._effective_pagination(), "offset")
+
+    def test_effective_pagination_cursor_threading_warns(self):
+        """Confirming cursor support with threading=True warns about the no-op."""
+        api = pynetbox.api(host, pagination="cursor", threading=True)
+        with patch(
+            "requests.sessions.Session.get",
+            return_value=self.ResponseHeadersWithVersion("4.6"),
+        ):
+            with self.assertWarns(UserWarning):
+                self.assertEqual(api._effective_pagination(), "cursor")
+
+    def test_effective_pagination_offset_fallback_does_not_warn(self):
+        """Falling back to offset (NetBox < 4.6) leaves threading functional."""
+        import warnings
+
+        api = pynetbox.api(host, pagination="cursor", threading=True)
+        with patch(
+            "requests.sessions.Session.get",
+            return_value=self.ResponseHeadersWithVersion("4.5"),
+        ):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                self.assertEqual(api._effective_pagination(), "offset")
 
 
 class ApiStatusTestCase(unittest.TestCase):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -142,6 +142,19 @@ class ApiPaginationTestCase(unittest.TestCase):
         self.assertEqual(api._effective_pagination(), "offset")
         mock_get.assert_not_called()
 
+    @patch("requests.sessions.Session.get")
+    def test_effective_pagination_cursor_deferred_until_iteration(self, mock_get):
+        """Building a cursor-mode RecordSet must not probe the server version.
+
+        The version lookup behind cursor pagination is resolved lazily on the
+        first page fetch, so an .all()/.filter() that is never iterated makes
+        no extra request.
+        """
+        api = pynetbox.api(host, pagination="cursor")
+        api.dcim.devices.all()
+        api.dcim.devices.filter(name="test")
+        mock_get.assert_not_called()
+
     def test_effective_pagination_cursor_supported(self):
         api = pynetbox.api(host, pagination="cursor")
         with patch(

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -72,6 +72,120 @@ class RequestTestCase(unittest.TestCase):
         )
 
 
+class CursorPaginationTestCase(unittest.TestCase):
+    """Tests for cursor-based pagination (NetBox 4.6+)."""
+
+    def test_first_request_sends_start_not_offset(self):
+        """Cursor mode should send start=0 (and never offset) on the first call."""
+        test_obj = Request(
+            http_session=Mock(),
+            base="http://localhost:8001/api/dcim/devices",
+            limit=2,
+            pagination="cursor",
+        )
+        test_obj.http_session.get.return_value.ok = True
+        test_obj.http_session.get.return_value.json.return_value = {
+            "count": None,
+            "next": None,
+            "previous": None,
+            "results": [{"id": 1}, {"id": 2}],
+        }
+
+        list(test_obj.get())
+
+        call_args = test_obj.http_session.get.call_args
+        self.assertEqual(call_args.kwargs["params"], {"limit": 2, "start": 0})
+        self.assertNotIn("offset", call_args.kwargs["params"])
+
+    def test_follows_next_links_sequentially(self):
+        """Cursor mode should follow server next links until exhausted."""
+        test_obj = Request(
+            http_session=Mock(),
+            base="http://localhost:8001/api/dcim/devices",
+            limit=2,
+            pagination="cursor",
+        )
+        page1 = {
+            "count": None,
+            "next": "http://localhost:8001/api/dcim/devices/?limit=2&start=3",
+            "previous": None,
+            "results": [{"id": 1}, {"id": 2}],
+        }
+        page2 = {
+            "count": None,
+            "next": "http://localhost:8001/api/dcim/devices/?limit=2&start=5",
+            "previous": None,
+            "results": [{"id": 3}, {"id": 4}],
+        }
+        page3 = {
+            "count": None,
+            "next": None,
+            "previous": None,
+            "results": [{"id": 5}],
+        }
+        responses = [page1, page2, page3]
+        test_obj.http_session.get.return_value.ok = True
+        test_obj.http_session.get.return_value.json.side_effect = responses
+
+        results = list(test_obj.get())
+
+        self.assertEqual([r["id"] for r in results], [1, 2, 3, 4, 5])
+        # Subsequent pages are fetched via the server-provided next URLs.
+        next_urls = [
+            c.args[0] for c in test_obj.http_session.get.call_args_list[1:]
+        ]
+        self.assertEqual(
+            next_urls,
+            [
+                "http://localhost:8001/api/dcim/devices/?limit=2&start=3",
+                "http://localhost:8001/api/dcim/devices/?limit=2&start=5",
+            ],
+        )
+
+    def test_explicit_offset_falls_back_to_offset(self):
+        """An explicit offset opts out of cursor mode (mutually exclusive)."""
+        test_obj = Request(
+            http_session=Mock(),
+            base="http://localhost:8001/api/dcim/devices",
+            limit=10,
+            offset=20,
+            pagination="cursor",
+        )
+        test_obj.http_session.get.return_value.ok = True
+        test_obj.http_session.get.return_value.json.return_value = {
+            "count": 4,
+            "next": None,
+            "previous": None,
+            "results": [1, 2, 3, 4],
+        }
+
+        list(test_obj.get())
+
+        call_args = test_obj.http_session.get.call_args
+        self.assertEqual(call_args.kwargs["params"], {"offset": 20, "limit": 10})
+        self.assertNotIn("start", call_args.kwargs["params"])
+
+    def test_get_count_fetched_when_null(self):
+        """get_count() refetches when cursor pagination left count as None."""
+        test_obj = Request(
+            http_session=Mock(),
+            base="http://localhost:8001/api/dcim/devices",
+            pagination="cursor",
+        )
+        test_obj.count = None
+        test_obj.http_session.get.return_value.ok = True
+        test_obj.http_session.get.return_value.json.return_value = {
+            "count": 99,
+            "next": None,
+            "previous": None,
+            "results": [],
+        }
+
+        self.assertEqual(test_obj.get_count(), 99)
+        call_args = test_obj.http_session.get.call_args
+        self.assertEqual(call_args.kwargs["params"], {"limit": 1, "brief": 1})
+
+
 class TokenDetectionTestCase(unittest.TestCase):
     """Tests for v1 vs v2 token detection."""
 

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -166,6 +166,50 @@ class CursorPaginationTestCase(unittest.TestCase):
         self.assertEqual(call_args.kwargs["params"], {"offset": 20, "limit": 10})
         self.assertNotIn("start", call_args.kwargs["params"])
 
+    def test_ordering_filter_warns(self):
+        """An 'ordering' filter has no effect in cursor mode, so warn."""
+        test_obj = Request(
+            http_session=Mock(),
+            base="http://localhost:8001/api/dcim/devices",
+            filters={"ordering": "name"},
+            limit=2,
+            pagination="cursor",
+        )
+        test_obj.http_session.get.return_value.ok = True
+        test_obj.http_session.get.return_value.json.return_value = {
+            "count": None,
+            "next": None,
+            "previous": None,
+            "results": [{"id": 1}],
+        }
+
+        with self.assertWarns(UserWarning) as ctx:
+            list(test_obj.get())
+        self.assertIn("ordering", str(ctx.warning))
+
+    def test_ordering_filter_no_warn_offset(self):
+        """Offset pagination honors 'ordering', so it must not warn."""
+        import warnings
+
+        test_obj = Request(
+            http_session=Mock(),
+            base="http://localhost:8001/api/dcim/devices",
+            filters={"ordering": "name"},
+            limit=2,
+            pagination="offset",
+        )
+        test_obj.http_session.get.return_value.ok = True
+        test_obj.http_session.get.return_value.json.return_value = {
+            "count": 1,
+            "next": None,
+            "previous": None,
+            "results": [{"id": 1}],
+        }
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            list(test_obj.get())
+
     def test_get_count_fetched_when_null(self):
         """get_count() refetches when cursor pagination left count as None."""
         test_obj = Request(

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -727,6 +727,26 @@ class RecordSetTestCase(unittest.TestCase):
             )
             self.assertTrue(test)
 
+    def test_len_fetches_count_in_cursor_mode(self):
+        """len() falls back to get_count() when count is None (cursor mode)."""
+        from pynetbox.core.query import Request
+
+        req = Request(
+            http_session=Mock(),
+            base="http://localhost:8000/api/dcim/devices",
+            pagination="cursor",
+        )
+        # Simulate a cursor-paginated response: count omitted (null).
+        req.http_session.get.return_value.ok = True
+        req.http_session.get.return_value.json.side_effect = [
+            {"count": None, "next": None, "previous": None, "results": [{"id": 1}]},
+            {"count": 7, "next": None, "previous": None, "results": []},
+        ]
+        api = Mock(base_url="http://localhost:8000/api")
+        app = Mock(name="dcim")
+        record_set = RecordSet(Endpoint(api, app, "devices"), req)
+        self.assertEqual(len(record_set), 7)
+
     def test_update(self):
         with patch(
             "pynetbox.core.query.Request._make_call", return_value=Mock()


### PR DESCRIPTION
### Fixes: #764 

Adds opt-in cursor-based pagination for .all() and .filter(). NetBox 4.6 introduced cursor pagination as an alternative to offset pagination: instead of skipping a growing number of rows with offset, the server pages forward using the primary key as a cursor, which performs significantly better on very large result sets.

## Usage
```
nb = pynetbox.api(url, token=token, pagination="cursor")
devices = nb.dcim.devices.all()  # pages via the server's `start` cursor, following `next` links
```

pagination defaults to "offset", so existing behavior is unchanged.

Below is a script that shows the new pagination, will need to update the token.

 <details>
  <summary>Manual verification script</summary>

  ```python
#!/usr/bin/env python3
"""Manual test for cursor-based pagination (NetBox 4.6+, PR #787).

Exercises the cursor pagination path of ``.all()`` / ``.filter()`` against a
live NetBox instance and verifies the review-comment fixes:

  1. ``pagination="cursor"`` walks every page by following the server's
     ``next`` links and returns the same objects as offset pagination.
  2. ``len()`` on a cursor RecordSet refetches the count NetBox omits (null)
     in cursor mode.
  3. ``threading=True`` + ``pagination="cursor"`` emits a UserWarning because
     cursor pages are fetched sequentially (the threading config is a no-op).
  4. A transport-level failure in the version probe falls back to offset
     instead of propagating (api.py exception handling).

Requires a NetBox 4.6+ instance whose ``dcim.devices`` endpoint has more than
one page of results (the script forces a small page size to guarantee this).

Usage: python manual_tests/test_cursor_pagination.py
"""

import os
import sys
import warnings
from unittest.mock import patch

import requests

sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

import pynetbox
from packaging import version

NETBOX_URL = os.environ.get("NETBOX_URL", "http://127.0.0.1:8000/")
NETBOX_TOKEN = "nbt_cUOdzNJvWx3q.v1YQC2Q1smP0PyN4soKGucD3BrbYZcu1qyztXu2c"

# Small page size so the device list spans multiple cursor pages and the
# next-link following is actually exercised.
PAGE_SIZE = 2


def test_version_and_effective_pagination():
    print("1. server version + effective pagination resolution")
    api = pynetbox.api(NETBOX_URL, token=NETBOX_TOKEN, pagination="cursor")
    server_version = api.version
    print(f"   NetBox {server_version} at {NETBOX_URL}")
    if version.parse(server_version) < version.parse("4.6"):
        raise SystemExit(
            f"   NetBox {server_version} does not support cursor pagination "
            "(need 4.6+); aborting."
        )
    effective = api._effective_pagination()
    assert effective == "cursor", f"expected 'cursor', got {effective!r}"
    print("   _effective_pagination() == 'cursor'")
    return api


def test_cursor_matches_offset(cursor_api):
    print("2. cursor pagination returns the same devices as offset")
    offset_api = pynetbox.api(NETBOX_URL, token=NETBOX_TOKEN, pagination="offset")

    offset_devices = list(offset_api.dcim.devices.all())
    cursor_devices = list(cursor_api.dcim.devices.filter(limit=PAGE_SIZE))

    print(f"   offset returned {len(offset_devices)} device(s)")
    print(f"   cursor returned {len(cursor_devices)} device(s) (page size {PAGE_SIZE})")

    assert len(cursor_devices) > PAGE_SIZE, (
        f"need more than one page of devices to test pagination; got "
        f"{len(cursor_devices)} with page size {PAGE_SIZE}"
    )

    offset_ids = sorted(d.id for d in offset_devices)
    cursor_ids = sorted(d.id for d in cursor_devices)
    assert offset_ids == cursor_ids, (
        "cursor and offset returned different device id sets:\n"
        f"   only in offset: {set(offset_ids) - set(cursor_ids)}\n"
        f"   only in cursor: {set(cursor_ids) - set(offset_ids)}"
    )
    print(f"   both strategies returned the same {len(cursor_ids)} device id(s)")


def test_cursor_len_refetches_count(cursor_api):
    print("3. len() on a cursor RecordSet refetches the omitted count")
    record_set = cursor_api.dcim.devices.filter(limit=PAGE_SIZE)
    count = len(record_set)
    print(f"   len(filter(limit={PAGE_SIZE})) == {count}")
    assert count > PAGE_SIZE, f"expected count > {PAGE_SIZE}, got {count}"


def test_threading_cursor_warns():
    print("4. threading=True + cursor emits a no-op warning")
    api = pynetbox.api(
        NETBOX_URL, token=NETBOX_TOKEN, pagination="cursor", threading=True
    )
    with warnings.catch_warnings(record=True) as caught:
        warnings.simplefilter("always")
        effective = api._effective_pagination()
    assert effective == "cursor", f"expected 'cursor', got {effective!r}"
    messages = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
    assert any("threading" in m for m in messages), (
        f"expected a threading no-op UserWarning, got: {messages}"
    )
    print(f"   warned: {messages[0]}")


def test_version_probe_network_error_falls_back():
    print("5. transport error in version probe falls back to offset")
    api = pynetbox.api(NETBOX_URL, token=NETBOX_TOKEN, pagination="cursor")
    with patch(
        "requests.sessions.Session.get",
        side_effect=requests.exceptions.ConnectionError("boom"),
    ):
        effective = api._effective_pagination()
    assert effective == "offset", f"expected 'offset', got {effective!r}"
    print("   ConnectionError during probe -> _effective_pagination() == 'offset'")


def main():
    api = test_version_and_effective_pagination()
    test_cursor_matches_offset(api)
    test_cursor_len_refetches_count(api)
    test_threading_cursor_warns()
    test_version_probe_network_error_falls_back()
    print("PASS")


if __name__ == "__main__":
    sys.exit(main())
  ```

  </details>