### PR TITLE
Release v7.8.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -11,7 +11,7 @@ body:
     attributes:
       label: pynetbox version
       description: What version of pynetbox are you currently running?
-      placeholder: v7.7.0
+      placeholder: v7.8.0
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: pynetbox version
       description: What version of pynetbox are you currently running?
-      placeholder: v7.1.0
+      placeholder: v7.8.0
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Each pyNetBox Version listed below has been tested with its corresponding NetBox
 
 | NetBox Version | Plugin Version |
 |:--------------:|:--------------:|
+|      4.6       |     7.8.0      |
 |      4.6       |     7.7.0      |
 |      4.5       |     7.6.1      |
 |      4.5       |     7.6.0      |

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,39 @@
 # Release Notes
 
+## Version 7.8.0 (June 18, 2026)
+
+#### Plugin Extension Framework ([#774](https://github.com/netbox-community/pynetbox/issues/774))
+
+pynetbox can now be extended to support third-party NetBox plugins without modifying the library. You can register custom record types for a plugin's endpoints, so working with plugin objects feels the same as working with built-in NetBox objects. The new branching ([#710](https://github.com/netbox-community/pynetbox/issues/710)) and Custom Objects ([#751](https://github.com/netbox-community/pynetbox/issues/751)) integrations are built on this framework.
+
+#### Custom Thread Pool Executor ([#633](https://github.com/netbox-community/pynetbox/issues/633))
+
+When threading is enabled, you can now control how the parallel requests behind `.all()` and `.filter()` are run. You can adjust how many worker threads are used, and supply your own executor — useful for carrying context such as tracing information into the worker threads.
+
+#### Cursor-Based Pagination ([#764](https://github.com/netbox-community/pynetbox/issues/764))
+
+pynetbox can now page through large result sets using NetBox 4.6's cursor-based pagination.
+
+#### Other New Features
+- [#713](https://github.com/netbox-community/pynetbox/issues/713) - Add `sync()` method to the `data_sources` endpoint
+- [#715](https://github.com/netbox-community/pynetbox/issues/715) - Allow endpoints with underscores
+
+#### Enhancements
+- [#625](https://github.com/netbox-community/pynetbox/issues/625) - Preserve JSON list fields instead of returning them as `Record`s
+
+#### Bug Fixes
+- [#701](https://github.com/netbox-community/pynetbox/issues/701) - Fix filtering for custom fields
+- [#749](https://github.com/netbox-community/pynetbox/issues/749) - Don't treat `Record` methods as constructors in `_parse_values`
+- [#745](https://github.com/netbox-community/pynetbox/issues/745) - Serialize list-`Record` items that lack an ID
+- [#519](https://github.com/netbox-community/pynetbox/issues/519) - Fix link peer casting
+- [#688](https://github.com/netbox-community/pynetbox/issues/688) - Skip network fetch for dunder attributes in `Record.__getattr__`
+- [#748](https://github.com/netbox-community/pynetbox/issues/748) - Stop re-sending PATCH for unchanged partial `custom_fields`
+
+#### Compatibility
+- Supports NetBox 4.6
+
+---
+
 ## Version 7.7.0 (May 5, 2026)
 
 #### New Features

--- a/pynetbox/__init__.py
+++ b/pynetbox/__init__.py
@@ -8,7 +8,7 @@ from pynetbox.core.query import (
 )
 from pynetbox.core.response import JsonField
 
-__version__ = "7.7.0"
+__version__ = "7.8.0"
 
 # Lowercase alias for backward compatibility
 api = Api


### PR DESCRIPTION
## Version 7.8.0 (June 18, 2026)

### Plugin Extension Framework ([#774](https://github.com/netbox-community/pynetbox/issues/774))

pynetbox can now be extended to support third-party NetBox plugins without modifying the library. You can register custom record types for a plugin's endpoints, so working with plugin objects feels the same as working with built-in NetBox objects. The new branching ([#710](https://github.com/netbox-community/pynetbox/issues/710)) and Custom Objects ([#751](https://github.com/netbox-community/pynetbox/issues/751)) integrations are built on this framework.

### Custom Thread Pool Executor ([#633](https://github.com/netbox-community/pynetbox/issues/633))

When threading is enabled, you can now control how the parallel requests behind `.all()` and `.filter()` are run. You can adjust how many worker threads are used, and supply your own executor - useful for carrying context such as tracing information into the worker threads.

### Cursor-Based Pagination ([#764](https://github.com/netbox-community/pynetbox/issues/764))

pynetbox can now page through large result sets using NetBox 4.6's cursor-based pagination.

### Other New Features
- [#713](https://github.com/netbox-community/pynetbox/issues/713) - Add `sync()` method to the `data_sources` endpoint
- [#715](https://github.com/netbox-community/pynetbox/issues/715) - Allow endpoints with underscores

### Enhancements
- [#625](https://github.com/netbox-community/pynetbox/issues/625) - Preserve JSON list fields instead of returning them as `Record`s

### Bug Fixes
- [#701](https://github.com/netbox-community/pynetbox/issues/701) - Fix filtering for custom fields
- [#749](https://github.com/netbox-community/pynetbox/issues/749) - Don't treat `Record` methods as constructors in `_parse_values`
- [#745](https://github.com/netbox-community/pynetbox/issues/745) - Serialize list-`Record` items that lack an ID
- [#519](https://github.com/netbox-community/pynetbox/issues/519) - Fix link peer casting
- [#688](https://github.com/netbox-community/pynetbox/issues/688) - Skip network fetch for dunder attributes in `Record.__getattr__`
- [#748](https://github.com/netbox-community/pynetbox/issues/748) - Stop re-sending PATCH for unchanged partial `custom_fields`